### PR TITLE
fix: Remove unnecessary .into call

### DIFF
--- a/src/client_features.rs
+++ b/src/client_features.rs
@@ -56,7 +56,7 @@ impl<'de> Deserialize<'de> for Operator {
             "SEMVER_EQ" => Operator::SemverEq,
             "SEMVER_LT" => Operator::SemverLt,
             "SEMVER_GT" => Operator::SemverGt,
-            _ => Operator::Unknown(s.into()),
+            _ => Operator::Unknown(s),
         })
     }
 }


### PR DESCRIPTION
As pointed out by https://github.com/Unleash/unleash-types-rs/security/code-scanning/1 this PR removes the unnecessary call to `.into()`