### PR TITLE
ci: try to use rust-cache instead of github cache action

### DIFF
--- a/.github/workflows/codequality.yaml
+++ b/.github/workflows/codequality.yaml
@@ -22,22 +22,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: ⚡ Cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            ~/.rustup
-            target
-          key: debug-${{ runner.os }}-stable
-          restore-keys: |
-            debug-${{ runner.os }}-
       - name: Install rust
         run: |
-          rustup install stable
-          rustup default stable
+          rustup set auto-self-update disable
+          rustup toolchain install stable --profile default
           rustup show
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
       - name: Install required cargo packages for reporting format
         run: cargo install clippy-sarif sarif-fmt
       - name: Run rust-clippy
@@ -50,6 +41,3 @@ jobs:
           sarif_file: rust-clippy-results.sarif
           category: clippy
           wait-for-processing: true
-      - name: Run tests
-        run: |
-          cargo test

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,22 +19,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: ⚡ Cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            ~/.rustup
-            target
-          key: release-${{ runner.os }}-stable
-          restore-keys: |
-            release-${{ runner.os }}-
       - name: Install rust
         run: |
-          rustup install stable
-          rustup default stable
+          rustup set auto-self-update disable
+          rustup toolchain install stable --profile minimal
           rustup show
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
       - name: Install required cargo packages for creating release
         run: |
           cargo install cargo-smart-release

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,5 +1,5 @@
 ---
-name: Run Test coverage
+name: Run Test and report Test coverage
 
 on:
   push:
@@ -10,27 +10,18 @@ on:
       - main
 
 jobs:
-  rust-clippy:
+  tarpaulin:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: ⚡ Cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            ~/.rustup
-            target
-          key: debug-${{ runner.os }}-stable
-          restore-keys: |
-            debug-${{ runner.os }}-
       - name: Install rust
         run: |
-          rustup install stable
-          rustup default stable
+          rustup set auto-self-update disable
+          rustup toolchain install stable --profile minimal
           rustup show
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
       - name: Install required cargo packages for reporting format
         run: cargo install cargo-tarpaulin
       - name: Run Tarpaulin (Test coverage)


### PR DESCRIPTION
### What
Update workflows to use Swatinem/rust-cache

### Why
The current cache setup doesn't cache the built artifacts causing us to have to build too much for small changes to the code. This PR is an attempt to optimise caching using rust-cache (an action optimised for caching rust-projects) rather than cache. The hope is that this will increase build speed for small changes