### PR TITLE
chore: u64 might require special treatment

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add unleash-types to your Cargo file.
 
 ### Client metrics
 
-- client_metrics::ClientAppliction struct represents the data expected by an Unleash server in a POST to the `/api/client/register` endpoint
+- client_metrics::ClientApplication struct represents the data expected by an Unleash server in a POST to the `/api/client/register` endpoint
 - client_metrics::ClientMetrics struct represents the data expected by an Unleash server in a POST to the `/api/client/metrics` endpoint
 
 ### Frontend types

--- a/src/client_metrics.rs
+++ b/src/client_metrics.rs
@@ -13,12 +13,12 @@ use crate::Merge;
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct ToggleStats {
     #[builder(default = "0")]
-    pub no: u64,
+    pub no: u32,
     #[builder(default = "0")]
-    pub yes: u64,
+    pub yes: u32,
     #[builder(default = "HashMap::new()")]
     #[serde(default)]
-    pub variants: HashMap<String, u64>,
+    pub variants: HashMap<String, u32>,
 }
 
 impl ToggleStats {
@@ -109,9 +109,9 @@ pub struct ClientMetricsEnv {
     pub app_name: String,
     pub environment: String,
     pub timestamp: DateTime<Utc>,
-    pub yes: u64,
-    pub no: u64,
-    pub variants: HashMap<String, u64>,
+    pub yes: u32,
+    pub no: u32,
+    pub variants: HashMap<String, u32>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Builder, PartialEq, Eq)]


### PR DESCRIPTION
## About the changes
Using u64 will require us to use [bigint](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-2.html#bigint) on the server side. It may also bring other interoperability problems with other languages. u32 should be enough and compatible with most languages.

As specified in https://www.rfc-editor.org/rfc/rfc7159:

>    This specification allows implementations to set limits on the range
>    and precision of numbers accepted.  Since software that implements
>    IEEE 754-2008 binary64 (double precision) numbers [[IEEE754](https://www.rfc-editor.org/rfc/rfc7159#ref-IEEE754)] is
>    generally available and widely used, good interoperability can be
>    achieved by implementations that expect no more precision or range
>    than these provide, in the sense that implementations will
>    approximate JSON numbers within the expected precision.  A JSON
>    number such as 1E400 or 3.141592653589793238462643383279 may indicate
>    potential interoperability problems, since it suggests that the
>    software that created it expects receiving software to have greater
>    capabilities for numeric magnitude and precision than is widely
>    available.
> 
>    Note that when such software is used, numbers that are integers and
>    are in the range [-(2**53)+1, (2**53)-1] are interoperable in the
>    sense that implementations will agree exactly on their numeric
>    values.