### PR TITLE
chore: use u32 and camelCase

### DIFF
--- a/src/client_features.rs
+++ b/src/client_features.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::{cmp::Ordering, collections::BTreeMap};
 #[cfg(feature = "openapi")]
-use utoipa::{ToSchema, IntoParams};
+use utoipa::{IntoParams, ToSchema};
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -167,7 +167,7 @@ pub struct Constraint {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "camelCase")]
 pub enum WeightType {
     Fix,
     Variable,

--- a/src/client_metrics.rs
+++ b/src/client_metrics.rs
@@ -130,14 +130,14 @@ pub struct ClientApplication {
     pub connect_via: Option<Vec<ConnectVia>>,
     pub environment: Option<String>,
     pub instance_id: Option<String>,
-    pub interval: u64,
+    pub interval: u32,
     pub sdk_version: Option<String>,
     pub started: DateTime<Utc>,
     pub strategies: Vec<String>,
 }
 
 impl ClientApplication {
-    pub fn new(app_name: &str, interval: u64) -> Self {
+    pub fn new(app_name: &str, interval: u32) -> Self {
         Self {
             app_name: app_name.into(),
             connect_via: Some(vec![]),


### PR DESCRIPTION
## About the changes
Follow up on #21, use camelCase which in case we ever add more enums and u32 as discussed in the other PR