### PR TITLE
feat: Adds an upsert method that prioritizes new incoming data

### DIFF
--- a/src/client_metrics.rs
+++ b/src/client_metrics.rs
@@ -309,7 +309,7 @@ mod tests {
             environment: None,
             instance_id: None,
             sdk_version: Some("unleash-client-java:7.1.0".into()),
-            started: started,
+            started,
             strategies: vec!["default".into(), "gradualRollout".into()],
         };
 
@@ -365,7 +365,7 @@ mod tests {
             environment: None,
             instance_id: None,
             sdk_version: Some("unleash-client-java:7.1.0".into()),
-            started: started,
+            started,
             strategies: vec!["default".into(), "gradualRollout".into()],
         };
 
@@ -411,7 +411,7 @@ mod tests {
             environment: None,
             instance_id: None,
             sdk_version: Some("unleash-client-java:7.1.0".into()),
-            started: started,
+            started,
             strategies: vec!["default".into(), "gradualRollout".into()],
         };
 

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -14,6 +14,7 @@ pub struct FrontendResult {
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct EvaluatedToggle {
     pub name: String,
+    pub project: String,
     pub enabled: bool,
     pub variant: EvaluatedVariant,
     pub impression_data: bool,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,11 @@ pub trait Merge {
     fn merge(self, other: Self) -> Self;
 }
 
+pub trait Upsert {
+    /// If same entry exists in both self and other, should keep the one in other, if entry only exists in one, keep it.
+    fn upsert(self, other: Self) -> Self;
+}
+
 pub trait Deduplicate<T>
 where
     T: Hash + Eq,
@@ -23,6 +28,17 @@ where
             .collect::<HashSet<T>>()
             .into_iter()
             .collect()
+    }
+}
+
+impl<T> Upsert for Vec<T>
+where
+    T: Hash + Eq,
+{
+    fn upsert(self, other: Self) -> Self {
+        let mut upserted = other;
+        upserted.extend(self);
+        upserted.deduplicate()
     }
 }
 


### PR DESCRIPTION
The existing merge method prioritizes the left side of the operation, making sure that when we got new data we still kept the old one. This broke feature refreshing for Edge. 

This PR adds a right side favouring upsert method, which means that it will still retain data from left hand side of the operation, but features with same name as existing features in left hand side will be overwritten by this method.

