### PR TITLE
feat: add support for strategy variants

### DIFF
--- a/examples/16-strategy-variants.json
+++ b/examples/16-strategy-variants.json
@@ -1,0 +1,158 @@
+{
+  "version": 1,
+  "features": [
+    {
+      "name": "Feature.strategy.variant.with.constraint",
+      "description": "Strategy variants based on constraint",
+      "enabled": true,
+      "strategies": [
+        {
+          "name": "flexibleRollout",
+          "variants": [
+            {
+              "name": "variantName",
+              "weight": 1,
+              "payload": {
+                "type": "string",
+                "value": "variantValue"
+              }
+            }
+          ],
+          "parameters": {
+            "rollout": "100",
+            "stickiness": "default",
+            "groupId": "a"
+          },
+          "constraints": [
+            {
+              "contextName": "environment",
+              "operator": "IN",
+              "values": ["dev"]
+            }
+          ]
+        }
+      ],
+      "variants": []
+    },
+    {
+      "name": "Feature.strategy.variant.overrides.feature.variant",
+      "description": "Strategy variants with feature variants",
+      "enabled": true,
+      "strategies": [
+        {
+          "name": "flexibleRollout",
+          "parameters": {
+            "rollout": "100",
+            "stickiness": "default",
+            "groupId": "a"
+          },
+          "variants": [
+            {
+              "name": "variantName",
+              "weight": 1,
+              "payload": {
+                "type": "string",
+                "value": "variantValue"
+              }
+            }
+          ],
+          "constraints": [
+            {
+              "contextName": "environment",
+              "operator": "IN",
+              "values": ["dev"]
+            }
+          ]
+        }
+      ],
+      "variants": [
+        {
+          "name": "featureVariant",
+          "weight": 1,
+          "payload": {
+            "type": "string",
+            "value": "willBeIgnored"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Feature.strategy.multiple.variants",
+      "description": "Strategy variants with multiple options",
+      "enabled": true,
+      "strategies": [
+        {
+          "name": "flexibleRollout",
+          "parameters": {
+            "rollout": "100",
+            "stickiness": "default",
+            "groupId": "a"
+          },
+          "variants": [
+            {
+              "name": "variantNameA",
+              "weight": 1,
+              "payload": {
+                "type": "string",
+                "value": "variantValueA"
+              }
+            },
+            {
+              "name": "variantNameB",
+              "weight": 1,
+              "payload": {
+                "type": "string",
+                "value": "variantValueB"
+              }
+            }
+          ],
+          "constraints": []
+        }
+      ],
+      "variants": []
+    },
+    {
+      "name": "Feature.strategy.empty.variants",
+      "description": "Strategy variants with empty variant options",
+      "enabled": true,
+      "strategies": [
+        {
+          "name": "flexibleRollout",
+          "variants": [],
+          "parameters": {
+            "rollout": "100",
+            "stickiness": "default",
+            "groupId": "a"
+          },
+          "constraints": []
+        }
+      ],
+      "variants": []
+    },
+    {
+      "name": "Feature.strategy.variant.fallback",
+      "description": "Strategy variants fall back to feature variants",
+      "enabled": true,
+      "strategies": [
+        {
+          "name": "flexibleRollout",
+          "parameters": {
+            "rollout": "100",
+            "stickiness": "default",
+            "groupId": "a"
+          }
+        }
+      ],
+      "variants": [
+        {
+          "name": "featureVariant",
+          "weight": 1,
+          "payload": {
+            "type": "string",
+            "value": "fallbackValue"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/client_features.rs
+++ b/src/client_features.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 #[cfg(feature = "hashes")]
 use xxhash_rust::xxh3::xxh3_128;
 
+use crate::frontend::EvaluatedVariant;
 use crate::{Deduplicate, Merge, Upsert};
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -205,6 +206,7 @@ pub struct Strategy {
         skip_serializing_if = "Option::is_none"
     )]
     pub parameters: Option<HashMap<String, String>>,
+    pub variant: Option<EvaluatedVariant>,
 }
 
 impl PartialEq for Strategy {
@@ -570,6 +572,7 @@ mod tests {
                 segments: None,
                 constraints: None,
                 parameters: None,
+                variant: None,
             }]),
             ..ClientFeature::default()
         };
@@ -581,6 +584,7 @@ mod tests {
                 segments: None,
                 constraints: None,
                 parameters: None,
+                variant: None,
             }]),
             ..ClientFeature::default()
         };

--- a/src/client_features.rs
+++ b/src/client_features.rs
@@ -11,7 +11,6 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 #[cfg(feature = "hashes")]
 use xxhash_rust::xxh3::xxh3_128;
 
-use crate::frontend::EvaluatedVariant;
 use crate::{Deduplicate, Merge, Upsert};
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -206,7 +205,7 @@ pub struct Strategy {
         skip_serializing_if = "Option::is_none"
     )]
     pub parameters: Option<HashMap<String, String>>,
-    pub variant: Option<EvaluatedVariant>,
+    pub variants: Option<Vec<StrategyVariant>>,
 }
 
 impl PartialEq for Strategy {
@@ -265,6 +264,16 @@ pub struct Variant {
     pub payload: Option<Payload>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub overrides: Option<Vec<Override>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[serde(rename_all = "camelCase")]
+pub struct StrategyVariant {
+    pub name: String,
+    pub weight: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payload: Option<Payload>,
 }
 
 impl PartialOrd for Variant {
@@ -572,7 +581,7 @@ mod tests {
                 segments: None,
                 constraints: None,
                 parameters: None,
-                variant: None,
+                variants: None,
             }]),
             ..ClientFeature::default()
         };
@@ -584,7 +593,7 @@ mod tests {
                 segments: None,
                 constraints: None,
                 parameters: None,
-                variant: None,
+                variants: None,
             }]),
             ..ClientFeature::default()
         };

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -19,10 +19,15 @@ pub struct EvaluatedToggle {
     pub impression_data: bool,
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct EvaluatedVariant {
     pub name: String,
+    #[serde(default = "default_true")]
     pub enabled: bool,
     pub payload: Option<Payload>,
+}
+
+fn default_true() -> bool {
+    true
 }

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -19,15 +19,10 @@ pub struct EvaluatedToggle {
     pub impression_data: bool,
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct EvaluatedVariant {
     pub name: String,
-    #[serde(default = "default_true")]
     pub enabled: bool,
     pub payload: Option<Payload>,
-}
-
-fn default_true() -> bool {
-    true
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,7 @@ mod tests {
     #[test_case("14-constraint-semver-operators"; "can parse semver constraints")]
     #[test_case("15-global-constraints"; "can parse segments")]
     #[test_case("features_with_variantType"; "can handle weightType being part of content")]
+    #[test_case("16-strategy-variants"; "can parse strategy variants")]
     pub fn run_parse_test(file_path: &str) {
         let content = fs::read_to_string(format!("./examples/{file_path}.json"))
             .expect("Could not read file");


### PR DESCRIPTION
This adds support to handle the new strategy variant format defined in the client spec version 4.3.x

This patch will allow Edge to forward on this data and support server side SDKs to consume strategy variants via Edge