### PR TITLE
task: try to extend query string parsing to support unknown keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,6 +335,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -435,6 +456,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_qs",
+ "serde_urlencoded",
  "test-case",
  "utoipa",
  "xxhash-rust",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ chrono = { version = "0.4.24", features = ["serde"] }
 derive_builder = "0.12.0"
 serde = { version = "1.0.160", features = ["derive"] }
 serde_json = "1.0.96"
+serde_urlencoded = "0.7.1"
 utoipa = { version = "3.2.1", optional = true, features = ["chrono"] }
 xxhash-rust = { version = "0.8.6", features = ["xxh3"], optional = true}
 [dev-dependencies]


### PR DESCRIPTION
```slack
nick
:spiral_calendar_pad:  [19 hours ago](https://unleash-internal.slack.com/archives/C05QDP90V9D/p1695320626756109)
Separate question than the one above. I am trying to use the frontend API in edge... for some reason my context query string parameters are not filtering my results back (when I add account type = gold it should return a flag i have with that as a context field)
curl -v -H "Authorization: *:default.e306777276c1a02d3054e1c0b8f4620725c0ec107e5f9d1b6d12e1d6" http://localhost:3063/api/frontend\?accountType=gold | jq
```