### PR TITLE
feat: add `dependencies` property to client feature struct

### DIFF
--- a/examples/17-dependent-features.json
+++ b/examples/17-dependent-features.json
@@ -1,0 +1,695 @@
+{
+  "version": 1,
+  "features": [
+    {
+      "name": "parent.enabled",
+      "description": "Parent feature that is always enabled",
+      "enabled": true,
+      "strategies": [
+        {
+          "name": "default"
+        }
+      ]
+    },
+    {
+      "name": "parent.disabled",
+      "description": "Parent feature that is always disabled",
+      "enabled": false,
+      "strategies": [
+        {
+          "name": "default"
+        }
+      ]
+    },
+    {
+      "name": "parent.with.variant",
+      "description": "Parent feature with variant",
+      "enabled": true,
+      "strategies": [
+        {
+          "name": "flexibleRollout",
+          "parameters": {
+            "rollout": "100",
+            "stickiness": "default",
+            "groupId": "parent"
+          },
+          "variants": [
+            {
+              "name": "parent.variant",
+              "weight": 1,
+              "payload": {
+                "type": "string",
+                "value": "variantValue"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "parent.with.constraint",
+      "description": "Parent feature with constraint",
+      "enabled": true,
+      "strategies": [
+        {
+          "name": "flexibleRollout",
+          "parameters": {
+            "rollout": "100",
+            "stickiness": "default",
+            "groupId": "parent"
+          },
+          "constraints": [
+            {
+              "contextName": "environment",
+              "operator": "IN",
+              "values": [
+                "prod"
+              ]
+            }
+          ],
+          "variants": [
+            {
+              "name": "parent.variant",
+              "weight": 1,
+              "payload": {
+                "type": "string",
+                "value": "variantValue"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "child.with.matching.constraint",
+      "description": "Child with parent matching constraint",
+      "enabled": true,
+      "dependencies": [
+        {
+          "feature": "parent.with.constraint"
+        }
+      ],
+      "strategies": [
+        {
+          "name": "flexibleRollout",
+          "parameters": {
+            "rollout": "100",
+            "stickiness": "default",
+            "groupId": "parent"
+          },
+          "constraints": [
+            {
+              "contextName": "environment",
+              "operator": "IN",
+              "values": [
+                "prod"
+              ]
+            }
+          ],
+          "variants": [
+            {
+              "name": "child.variant",
+              "weight": 1,
+              "payload": {
+                "type": "string",
+                "value": "variantValue"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "child.with.non.matching.constraint",
+      "description": "Child with parent not matching constraint",
+      "enabled": true,
+      "dependencies": [
+        {
+          "feature": "parent.with.constraint"
+        }
+      ],
+      "strategies": [
+        {
+          "name": "flexibleRollout",
+          "parameters": {
+            "rollout": "100",
+            "stickiness": "default",
+            "groupId": "parent"
+          },
+          "constraints": [
+            {
+              "contextName": "environment",
+              "operator": "IN",
+              "values": [
+                "dev"
+              ]
+            }
+          ],
+          "variants": [
+            {
+              "name": "child.variant",
+              "weight": 1,
+              "payload": {
+                "type": "string",
+                "value": "variantValue"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "parent.with.cycle",
+      "description": "Parent with cycle to child",
+      "enabled": true,
+      "dependencies": [
+        {
+          "feature": "child.with.cycle"
+        }
+      ],
+      "strategies": [
+        {
+          "name": "flexibleRollout",
+          "parameters": {
+            "rollout": "100",
+            "stickiness": "default",
+            "groupId": "parent"
+          },
+          "variants": [
+            {
+              "name": "parent.variant",
+              "weight": 1,
+              "payload": {
+                "type": "string",
+                "value": "variantValue"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "child.with.cycle",
+      "description": "Child with cycle to parent",
+      "enabled": true,
+      "dependencies": [
+        {
+          "feature": "parent.with.cycle"
+        }
+      ],
+      "strategies": [
+        {
+          "name": "flexibleRollout",
+          "parameters": {
+            "rollout": "100",
+            "stickiness": "default",
+            "groupId": "parent"
+          },
+          "variants": [
+            {
+              "name": "parent.variant",
+              "weight": 1,
+              "payload": {
+                "type": "string",
+                "value": "variantValue"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "child.with.transitive.dependency",
+      "description": "Child with transitive dependency",
+      "enabled": true,
+      "dependencies": [
+        {
+          "feature": "parent.enabled.child.enabled"
+        }
+      ],
+      "strategies": [
+        {
+          "name": "flexibleRollout",
+          "parameters": {
+            "rollout": "100",
+            "stickiness": "default",
+            "groupId": "parent"
+          },
+          "variants": [
+            {
+              "name": "parent.variant",
+              "weight": 1,
+              "payload": {
+                "type": "string",
+                "value": "variantValue"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "parent.enabled.child.enabled",
+      "description": "Parent enabled, child enabled",
+      "enabled": true,
+      "dependencies": [
+        {
+          "feature": "parent.enabled"
+        }
+      ],
+      "strategies": [
+        {
+          "name": "flexibleRollout",
+          "parameters": {
+            "rollout": "100",
+            "stickiness": "default",
+            "groupId": "groupId"
+          },
+          "variants": [
+            {
+              "name": "child.variant",
+              "weight": 1,
+              "payload": {
+                "type": "string",
+                "value": "variantValue"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "parent.enabled.child.disabled",
+      "description": "Parent enabled, child disabled",
+      "enabled": false,
+      "dependencies": [
+        {
+          "feature": "parent.enabled"
+        }
+      ],
+      "strategies": [
+        {
+          "name": "flexibleRollout",
+          "parameters": {
+            "rollout": "100",
+            "stickiness": "default",
+            "groupId": "groupId"
+          },
+          "variants": [
+            {
+              "name": "child.variant",
+              "weight": 1,
+              "payload": {
+                "type": "string",
+                "value": "variantValue"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "parent.disabled.child.enabled",
+      "description": "Parent disabled, child enabled",
+      "enabled": true,
+      "dependencies": [
+        {
+          "feature": "parent.disabled"
+        }
+      ],
+      "strategies": [
+        {
+          "name": "flexibleRollout",
+          "parameters": {
+            "rollout": "100",
+            "stickiness": "default",
+            "groupId": "groupId"
+          },
+          "variants": [
+            {
+              "name": "child.variant",
+              "weight": 1,
+              "payload": {
+                "type": "string",
+                "value": "variantValue"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "parent.disabled.child.disabled",
+      "description": "Parent disabled, child disabled",
+      "enabled": false,
+      "dependencies": [
+        {
+          "feature": "parent.disabled"
+        }
+      ],
+      "strategies": [
+        {
+          "name": "flexibleRollout",
+          "parameters": {
+            "rollout": "100",
+            "stickiness": "default",
+            "groupId": "groupId"
+          },
+          "variants": [
+            {
+              "name": "child.variant",
+              "weight": 1,
+              "payload": {
+                "type": "string",
+                "value": "variantValue"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "parent.default.variant.child.enabled",
+      "description": "Parent enabled with no explicit variant, child enabled",
+      "enabled": true,
+      "dependencies": [
+        {
+          "feature": "parent.enabled",
+          "variants": [
+            "disabled"
+          ]
+        }
+      ],
+      "strategies": [
+        {
+          "name": "flexibleRollout",
+          "parameters": {
+            "rollout": "100",
+            "stickiness": "default",
+            "groupId": "groupId"
+          },
+          "variants": [
+            {
+              "name": "child.variant",
+              "weight": 1,
+              "payload": {
+                "type": "string",
+                "value": "variantValue"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "parent.disabled.satisfied.child.enabled",
+      "description": "Parent disabled expectation satisfied, child enabled",
+      "enabled": true,
+      "dependencies": [
+        {
+          "feature": "parent.disabled",
+          "enabled": false
+        }
+      ],
+      "strategies": [
+        {
+          "name": "flexibleRollout",
+          "parameters": {
+            "rollout": "100",
+            "stickiness": "default",
+            "groupId": "groupId"
+          },
+          "variants": [
+            {
+              "name": "child.variant",
+              "weight": 1,
+              "payload": {
+                "type": "string",
+                "value": "variantValue"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "parent.disabled.not.satisfied.child.enabled",
+      "description": "Parent disabled expectation not satisfied, child enabled",
+      "enabled": true,
+      "dependencies": [
+        {
+          "feature": "parent.enabled",
+          "enabled": false
+        }
+      ],
+      "strategies": [
+        {
+          "name": "flexibleRollout",
+          "parameters": {
+            "rollout": "100",
+            "stickiness": "default",
+            "groupId": "groupId"
+          },
+          "variants": [
+            {
+              "name": "child.variant",
+              "weight": 1,
+              "payload": {
+                "type": "string",
+                "value": "variantValue"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "parent.single.variant.child.enabled",
+      "description": "Parent single variant match, child enabled",
+      "enabled": true,
+      "dependencies": [
+        {
+          "feature": "parent.with.variant",
+          "variants": [
+            "parent.variant"
+          ]
+        }
+      ],
+      "strategies": [
+        {
+          "name": "flexibleRollout",
+          "parameters": {
+            "rollout": "100",
+            "stickiness": "default",
+            "groupId": "groupId"
+          },
+          "variants": [
+            {
+              "name": "child.variant",
+              "weight": 1,
+              "payload": {
+                "type": "string",
+                "value": "variantValue"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "parent.multiple.variants.child.enabled",
+      "description": "Parent multiples variants match, child enabled",
+      "enabled": true,
+      "dependencies": [
+        {
+          "feature": "parent.with.variant",
+          "variants": [
+            "parent.variant",
+            "nonmatching.variant"
+          ]
+        }
+      ],
+      "strategies": [
+        {
+          "name": "flexibleRollout",
+          "parameters": {
+            "rollout": "100",
+            "stickiness": "default",
+            "groupId": "groupId"
+          },
+          "variants": [
+            {
+              "name": "child.variant",
+              "weight": 1,
+              "payload": {
+                "type": "string",
+                "value": "variantValue"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "parent.empty.variants.child.enabled",
+      "description": "Parent empty variants match, child enabled",
+      "enabled": true,
+      "dependencies": [
+        {
+          "feature": "parent.with.variant",
+          "variants": []
+        }
+      ],
+      "strategies": [
+        {
+          "name": "flexibleRollout",
+          "parameters": {
+            "rollout": "100",
+            "stickiness": "default",
+            "groupId": "groupId"
+          },
+          "variants": [
+            {
+              "name": "child.variant",
+              "weight": 1,
+              "payload": {
+                "type": "string",
+                "value": "variantValue"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "parent.non.matching.variant.child.enabled",
+      "description": "Parent non matching variant, child enabled",
+      "enabled": true,
+      "dependencies": [
+        {
+          "feature": "parent.with.variant",
+          "variants": [
+            "nonmatching.variant"
+          ]
+        }
+      ],
+      "strategies": [
+        {
+          "name": "flexibleRollout",
+          "parameters": {
+            "rollout": "100",
+            "stickiness": "default",
+            "groupId": "groupId"
+          },
+          "variants": [
+            {
+              "name": "child.variant",
+              "weight": 1,
+              "payload": {
+                "type": "string",
+                "value": "variantValue"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "multiple.parents.satisfied.child.enabled",
+      "description": "Multiple parents satisfied, child enabled",
+      "enabled": true,
+      "dependencies": [
+        {
+          "feature": "parent.enabled"
+        },
+        {
+          "feature": "parent.disabled",
+          "enabled": false
+        }
+      ],
+      "strategies": [
+        {
+          "name": "flexibleRollout",
+          "parameters": {
+            "rollout": "100",
+            "stickiness": "default",
+            "groupId": "groupId"
+          },
+          "variants": [
+            {
+              "name": "child.variant",
+              "weight": 1,
+              "payload": {
+                "type": "string",
+                "value": "variantValue"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "multiple.parents.not.satisfied.child.enabled",
+      "description": "Multiple parents not satisfied, child enabled",
+      "enabled": true,
+      "dependencies": [
+        {
+          "feature": "parent.enabled"
+        },
+        {
+          "feature": "parent.disabled"
+        }
+      ],
+      "strategies": [
+        {
+          "name": "flexibleRollout",
+          "parameters": {
+            "rollout": "100",
+            "stickiness": "default",
+            "groupId": "groupId"
+          },
+          "variants": [
+            {
+              "name": "child.variant",
+              "weight": 1,
+              "payload": {
+                "type": "string",
+                "value": "variantValue"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "parents.not.exist.child.enabled",
+      "description": "Parent does not exist, child enabled",
+      "enabled": true,
+      "dependencies": [
+        {
+          "feature": "parent.not.exist"
+        }
+      ],
+      "strategies": [
+        {
+          "name": "flexibleRollout",
+          "parameters": {
+            "rollout": "100",
+            "stickiness": "default",
+            "groupId": "groupId"
+          },
+          "variants": [
+            {
+              "name": "child.variant",
+              "weight": 1,
+              "payload": {
+                "type": "string",
+                "value": "variantValue"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/client_features.rs
+++ b/src/client_features.rs
@@ -319,6 +319,17 @@ impl Hash for Segment {
     }
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[serde(rename_all = "camelCase")]
+pub struct FeatureDependency {
+    pub feature: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub variants: Option<Vec<String>>,
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, Default)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 #[serde(rename_all = "camelCase")]
@@ -343,6 +354,8 @@ pub struct ClientFeature {
     pub strategies: Option<Vec<Strategy>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub variants: Option<Vec<Variant>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dependencies: Option<Vec<FeatureDependency>>,
 }
 
 impl Merge for ClientFeatures {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,7 @@ mod tests {
     #[test_case("15-global-constraints"; "can parse segments")]
     #[test_case("features_with_variantType"; "can handle weightType being part of content")]
     #[test_case("16-strategy-variants"; "can parse strategy variants")]
+    #[test_case("17-dependent-features"; "can parse feature dependencies")]
     pub fn run_parse_test(file_path: &str) {
         let content = fs::read_to_string(format!("./examples/{file_path}.json"))
             .expect("Could not read file");


### PR DESCRIPTION
This change adds the `dependencies` property to the client feature
struct, opening the path for dependent feature toggles:

https://github.com/Unleash/unleash/issues/2255