### PR TITLE
fix: add stickiness to strategy variants

### DIFF
--- a/src/client_features.rs
+++ b/src/client_features.rs
@@ -286,6 +286,8 @@ pub struct StrategyVariant {
     pub weight: i32,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub payload: Option<Payload>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stickiness: Option<String>,
 }
 
 impl PartialOrd for Variant {


### PR DESCRIPTION
This adds the stickiness property to the strategy variant struct. This shouldn't be necessary because the SDKs **shouldn't** need this property. But the JS SDK does rely on it, due to a bug and rolling that back is tough.

This allows us to support those versions of the JS SDK without creating incompatible versions of Unleash/Edge/SDK that don't work together