### PR TITLE
feat: extend metrics and registration with optional metadata

### DIFF
--- a/src/client_metrics.rs
+++ b/src/client_metrics.rs
@@ -74,6 +74,7 @@ pub fn from_bucket_app_name_and_env(
     bucket: MetricBucket,
     app_name: String,
     environment: String,
+    metadata: MetricsMetadata,
 ) -> Vec<ClientMetricsEnv> {
     let timestamp = bucket.start;
     bucket
@@ -87,6 +88,7 @@ pub fn from_bucket_app_name_and_env(
             yes: stats.yes,
             no: stats.no,
             variants: stats.variants,
+            metadata: metadata.clone(),
         })
         .collect()
 }
@@ -99,6 +101,8 @@ pub struct ClientMetrics {
     pub bucket: MetricBucket,
     pub environment: Option<String>,
     pub instance_id: Option<String>,
+    #[serde(flatten)]
+    pub metadata: MetricsMetadata,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -112,6 +116,8 @@ pub struct ClientMetricsEnv {
     pub yes: u32,
     pub no: u32,
     pub variants: HashMap<String, u32>,
+    #[serde(flatten)]
+    pub metadata: MetricsMetadata,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Builder, PartialEq, Eq)]
@@ -131,9 +137,20 @@ pub struct ClientApplication {
     pub environment: Option<String>,
     pub instance_id: Option<String>,
     pub interval: u32,
-    pub sdk_version: Option<String>,
     pub started: DateTime<Utc>,
     pub strategies: Vec<String>,
+    #[serde(flatten)]
+    pub metadata: MetricsMetadata,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Builder)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
+pub struct MetricsMetadata {
+    pub sdk_version: Option<String>,
+    pub yggdrasil_version: Option<String>,
+    pub platform_name: Option<String>,
+    pub platform_version: Option<String>,
 }
 
 impl ClientApplication {
@@ -144,9 +161,14 @@ impl ClientApplication {
             environment: None,
             instance_id: None,
             interval,
-            sdk_version: None,
             started: Utc::now(),
             strategies: vec![],
+            metadata: MetricsMetadata {
+                sdk_version: None,
+                yggdrasil_version: None,
+                platform_name: None,
+                platform_version: None,
+            },
         }
     }
 
@@ -202,10 +224,21 @@ impl Merge for ClientApplication {
             environment: self.environment.or(other.environment),
             instance_id: self.instance_id.or(other.instance_id),
             interval: self.interval,
-            sdk_version: self.sdk_version.or(other.sdk_version),
             started: self.started,
             strategies: merged_strategies,
             connect_via: merged_connected_via,
+            metadata: MetricsMetadata {
+                sdk_version: self.metadata.sdk_version.or(other.metadata.sdk_version),
+                yggdrasil_version: self
+                    .metadata
+                    .yggdrasil_version
+                    .or(other.metadata.yggdrasil_version),
+                platform_name: self.metadata.platform_name.or(other.metadata.platform_name),
+                platform_version: self
+                    .metadata
+                    .platform_version
+                    .or(other.metadata.platform_version),
+            },
         }
     }
 }
@@ -224,9 +257,20 @@ mod tests {
                 environment: Default::default(),
                 instance_id: Default::default(),
                 interval: Default::default(),
-                sdk_version: Default::default(),
                 started: Default::default(),
                 strategies: Default::default(),
+                metadata: Default::default(),
+            }
+        }
+    }
+
+    impl Default for MetricsMetadata {
+        fn default() -> Self {
+            Self {
+                sdk_version: Default::default(),
+                yggdrasil_version: Default::default(),
+                platform_name: Default::default(),
+                platform_version: Default::default(),
             }
         }
     }
@@ -299,16 +343,22 @@ mod tests {
             interval: 15500,
             environment: Some("development".into()),
             instance_id: Some("instance_id".into()),
-            sdk_version: Some("unleash-client-java:7.1.0".into()),
             started: Utc::now(),
             strategies: vec!["default".into(), "gradualRollout".into()],
+            metadata: MetricsMetadata {
+                sdk_version: Some("unleash-client-java:7.1.0".into()),
+                ..Default::default()
+            },
             ..Default::default()
         };
         // Cloning orig here, to avoid the destructive merge preventing us from testing
         let merged = demo_data_orig.clone().merge(demo_data_with_more_data);
         assert_eq!(merged.interval, demo_data_orig.interval);
         assert_eq!(merged.environment, Some("development".into()));
-        assert_eq!(merged.sdk_version, Some("unleash-client-java:7.1.0".into()));
+        assert_eq!(
+            merged.metadata.sdk_version,
+            Some("unleash-client-java:7.1.0".into())
+        );
         assert_eq!(merged.instance_id, Some("instance_id".into()));
         assert_eq!(merged.started, demo_data_orig.started);
         assert_eq!(merged.strategies.len(), 2);
@@ -320,9 +370,12 @@ mod tests {
         let demo_data_1 = ClientApplication {
             app_name: "demo".into(),
             interval: 15500,
-            sdk_version: Some("unleash-client-java:7.1.0".into()),
             started,
             strategies: vec!["default".into(), "gradualRollout".into()],
+            metadata: MetricsMetadata {
+                sdk_version: Some("unleash-client-java:7.1.0".into()),
+                ..Default::default()
+            },
             ..Default::default()
         };
 
@@ -371,9 +424,12 @@ mod tests {
             }]),
             app_name: "demo".into(),
             interval: 15500,
-            sdk_version: Some("unleash-client-java:7.1.0".into()),
             started,
             strategies: vec!["default".into(), "gradualRollout".into()],
+            metadata: MetricsMetadata {
+                sdk_version: Some("unleash-client-java:7.1.0".into()),
+                ..Default::default()
+            },
             ..Default::default()
         };
 
@@ -414,9 +470,12 @@ mod tests {
         let demo_data_1 = ClientApplication {
             app_name: "demo".into(),
             interval: 15500,
-            sdk_version: Some("unleash-client-java:7.1.0".into()),
             started,
             strategies: vec!["default".into(), "gradualRollout".into()],
+            metadata: MetricsMetadata {
+                sdk_version: Some("unleash-client-java:7.1.0".into()),
+                ..Default::default()
+            },
             ..Default::default()
         };
 
@@ -468,6 +527,9 @@ mod tests {
             bucket,
             "unleash_edge_metrics".into(),
             "development".into(),
+            MetricsMetadata {
+                ..Default::default()
+            },
         );
         assert_eq!(client_metrics_env.len(), 2);
         let feature_one_metrics = client_metrics_env
@@ -509,5 +571,161 @@ mod tests {
         let metrics: ClientMetrics = serde_json::from_str(serialized_metrics).unwrap();
         assert_eq!(metrics.bucket.toggles.get("some-feature").unwrap().yes, 1);
         assert_eq!(metrics.bucket.toggles.get("some-feature").unwrap().no, 0);
+    }
+
+    #[test]
+    fn metrics_can_be_deserialized_from_legacy_data_structure() {
+        let serialized_metrics = r#"
+        {
+            "appName": "some-app",
+            "instanceId": "some-instance",
+            "bucket": {
+              "start": "1867-11-07T12:00:00Z",
+              "stop": "1934-11-07T12:00:00Z",
+              "toggles": {}
+            }
+          }
+        "#;
+        let metrics: ClientMetrics =
+            serde_json::from_str(serialized_metrics).expect("Should have deserialized correctly");
+        assert_eq!(metrics.metadata.yggdrasil_version, None);
+    }
+
+    #[test]
+    fn metrics_can_be_deserialized_when_containing_metadata_fields() {
+        let serialized_metrics = r#"
+        {
+            "appName": "some-app",
+            "instanceId": "some-instance",
+            "bucket": {
+              "start": "1867-11-07T12:00:00Z",
+              "stop": "1934-11-07T12:00:00Z",
+              "toggles": {}
+            },
+            "sdkVersion": "malbolge-1.0.0"
+          }
+        "#;
+        let metrics: ClientMetrics =
+            serde_json::from_str(serialized_metrics).expect("Should have deserialized correctly");
+        assert_eq!(metrics.metadata.sdk_version, Some("malbolge-1.0.0".into()));
+    }
+
+    #[test]
+    fn registration_can_be_deserialized_from_legacy_data_structure() {
+        let serialized_registration = r#"
+        {
+            "appName": "some-app",
+            "environment": "some-instance",
+            "instanceId": "something",
+            "interval": 15000,
+            "started": "1867-11-07T12:00:00Z",
+            "strategies": ["I-made-this-up"]
+          }
+        "#;
+        let registration: ClientApplication = serde_json::from_str(serialized_registration)
+            .expect("Should have deserialized correctly");
+        assert_eq!(registration.metadata.yggdrasil_version, None);
+    }
+
+    #[test]
+    fn registration_can_be_deserialized_when_containing_metadata_fields() {
+        let serialized_metrics = r#"
+        {
+            "appName": "some-app",
+            "instanceId": "some-instance",
+            "bucket": {
+              "start": "1867-11-07T12:00:00Z",
+              "stop": "1934-11-07T12:00:00Z",
+              "toggles": {}
+            },
+            "sdkVersion": "malbolge-1.0.0"
+          }
+        "#;
+        let metrics: ClientMetrics =
+            serde_json::from_str(serialized_metrics).expect("Should have deserialized correctly");
+
+        assert_eq!(metrics.metadata.sdk_version, Some("malbolge-1.0.0".into()));
+    }
+
+    #[test]
+    fn metrics_metadata_is_flattened_during_serialization() {
+        let expected_metrics = r#"
+        {
+            "appName": "test-name",
+            "bucket": {
+              "start": "1970-01-01T00:16:40Z",
+              "stop": "1970-01-01T00:16:40Z",
+              "toggles": {}
+            },
+            "environment": "test-env",
+            "instanceId": "test-instance-id",
+            "sdkVersion": "rust-1.3.0",
+            "yggdrasilVersion": null,
+            "platformName": "rustc",
+            "platformVersion": "1.7.9"
+          }
+        "#
+        .replace(" ", "")
+        .replace("\n", "");
+
+        let metrics = ClientMetrics {
+            app_name: "test-name".into(),
+            environment: Some("test-env".into()),
+            instance_id: Some("test-instance-id".into()),
+            bucket: MetricBucket {
+                start: DateTime::<Utc>::from_timestamp(1000, 0).unwrap(),
+                stop: DateTime::<Utc>::from_timestamp(1000, 0).unwrap(),
+                toggles: HashMap::new(),
+            },
+            metadata: MetricsMetadata {
+                sdk_version: Some("rust-1.3.0".into()),
+                yggdrasil_version: None,
+                platform_name: Some("rustc".into()),
+                platform_version: Some("1.7.9".into()),
+            },
+        };
+
+        let json_string = serde_json::to_string(&metrics).unwrap();
+        assert_eq!(json_string, expected_metrics);
+    }
+
+    #[test]
+    fn registration_metadata_is_flattened_during_serialization() {
+        let expected_registration = r#"
+        {
+            "appName": "test-name",
+            "connectVia": null,
+            "environment": "test-env",
+            "instanceId": "test-instance-id",
+            "interval": 15000,
+            "started": "1970-01-01T00:16:40Z",
+            "strategies": [],
+            "sdkVersion": "rust-1.3.0",
+            "yggdrasilVersion": null,
+            "platformName": "rustc",
+            "platformVersion": "1.7.9"
+          }
+        "#
+        .replace(" ", "")
+        .replace("\n", "");
+
+        let metrics = ClientApplication {
+            app_name: "test-name".into(),
+            environment: Some("test-env".into()),
+            instance_id: Some("test-instance-id".into()),
+            metadata: MetricsMetadata {
+                sdk_version: Some("rust-1.3.0".into()),
+                yggdrasil_version: None,
+                platform_name: Some("rustc".into()),
+                platform_version: Some("1.7.9".into()),
+            },
+            connect_via: None,
+            interval: 15000,
+            started: DateTime::<Utc>::from_timestamp(1000, 0).unwrap(),
+            strategies: vec![],
+        };
+
+        let json_string = serde_json::to_string(&metrics).unwrap();
+        assert_eq!(json_string, expected_registration);
     }
 }


### PR DESCRIPTION
Extends the metrics and registration structs to accept metadata fields for the new metrics we want to ingest.

I've chosen to make this type non optional - you really should be filling in these fields when you're ingesting this data. The serialization, however, will happily ignore the missing fields. This is all rolled up into a single flattened struct so that it's easier to keep these fields together

Depends on  #38 and  #39 - kept separate from these because those facilitate making the logic change smaller