### PR TITLE
feat:  impl hash for query

### DIFF
--- a/src/client_features.rs
+++ b/src/client_features.rs
@@ -13,7 +13,7 @@ use xxhash_rust::xxh3::xxh3_128;
 
 use crate::{Deduplicate, Merge, Upsert};
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "openapi", derive(ToSchema, IntoParams))]
 #[serde(rename_all = "camelCase")]
 pub struct Query {


### PR DESCRIPTION
This change derives the Hash impl for Query. This should allow us to more easily use the query as a key in hash maps.

It's not currently behind the `hashes` flag because we already impl Hash for Feature and Segment without the flag. Of course, I'd be happy to move it behind the flag if we want it.