### PR TITLE
task: migrate to git cliff for our changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,159 +2,302 @@
 
 All notable changes to this project will be documented in this file.
 
+## [unreleased]
+
+### 💼 Other
+
+- Release plz workflow ([#45](https://github.com/unleash/unleash-types-rs/issues/45)) by @chriswk in #45
+
+- Migrate to git cliff for our changelog
+
+- Added username and pr numbers (if available) to changelog
+
+
 ## [0.15.0] - 2025-01-03
 
 ### 🚀 Features
 
-- Derives the hash impl for query ([#43](https://github.com/unleash/unleash-types-rs/issues/43))
+- Derives the hash impl for query ([#43](https://github.com/unleash/unleash-types-rs/issues/43)) by @thomasheartman in #43
+
+
+### 💼 Other
+
+- Clippy --fix ([#33](https://github.com/unleash/unleash-types-rs/issues/33)) by @gastonfournier in #33
+
+- Release unleash-types v0.15.0 by @thomasheartman
+
 
 ## [0.14.0] - 2024-10-18
 
+### 💼 Other
+
+- Release unleash-types v0.14.0 by @chriswk
+
+
 ### ⚙️ Miscellaneous Tasks
 
-- Dependency maintenance ([#42](https://github.com/unleash/unleash-types-rs/issues/42))
+- Dependency maintenance ([#42](https://github.com/unleash/unleash-types-rs/issues/42)) by @chriswk in #42
+
 
 ## [0.13.0] - 2024-07-19
 
 ### 🚀 Features
 
-- Extend metrics and registration with optional metadata ([#40](https://github.com/unleash/unleash-types-rs/issues/40))
+- Extend metrics and registration with optional metadata ([#40](https://github.com/unleash/unleash-types-rs/issues/40)) by @sighphyre in #40
+
 
 ### 🐛 Bug Fixes
 
-- Re-add snake-case of impression_data ([#41](https://github.com/unleash/unleash-types-rs/issues/41))
+- Re-add snake-case of impression_data ([#41](https://github.com/unleash/unleash-types-rs/issues/41)) by @chriswk in #41
+
+
+### 💼 Other
+
+- Release unleash-types v0.13.0 by @chriswk
+
 
 ### ⚙️ Miscellaneous Tasks
 
-- Clippy/cargo linting cleanups ([#38](https://github.com/unleash/unleash-types-rs/issues/38))
-- Change tests so that we can add fields to clientapplication without a lot of noise ([#39](https://github.com/unleash/unleash-types-rs/issues/39))
-- Chrono security bump
+- Clippy/cargo linting cleanups ([#38](https://github.com/unleash/unleash-types-rs/issues/38)) by @sighphyre in #38
+
+- Change tests so that we can add fields to clientapplication without a lot of noise ([#39](https://github.com/unleash/unleash-types-rs/issues/39)) by @sighphyre in #39
+
+- Chrono security bump by @chriswk
+
 
 ## [0.12.0] - 2024-04-25
 
 ### 🐛 Bug Fixes
 
-- Convert frontend responses to camel case ([#36](https://github.com/unleash/unleash-types-rs/issues/36))
+- Convert frontend responses to camel case ([#36](https://github.com/unleash/unleash-types-rs/issues/36)) by @sighphyre in #36
+
+
+### 💼 Other
+
+- Release unleash-types v0.12.0 by @sighphyre
+
 
 ## [0.11.0] - 2024-01-23
 
 ### 🐛 Bug Fixes
 
-- Add stickiness to strategy variants ([#34](https://github.com/unleash/unleash-types-rs/issues/34))
+- Add stickiness to strategy variants ([#34](https://github.com/unleash/unleash-types-rs/issues/34)) by @sighphyre in #34
+
+
+### 💼 Other
+
+- Release unleash-types v0.11.0 by @chriswk
+
 
 ## [0.10.6] - 2023-11-30
 
 ### 🐛 Bug Fixes
 
-- None strategy variants should serialize as empty array ([#32](https://github.com/unleash/unleash-types-rs/issues/32))
+- None strategy variants should serialize as empty array ([#32](https://github.com/unleash/unleash-types-rs/issues/32)) by @gastonfournier in #32
+
 
 ### ⚙️ Miscellaneous Tasks
 
-- Release unleash-types version 0.10.6
+- Release unleash-types version 0.10.6 by @gastonfournier
+
 
 ## [0.10.5] - 2023-10-12
 
 ### 🚀 Features
 
-- Add `dependencies` property to client feature struct ([#30](https://github.com/unleash/unleash-types-rs/issues/30))
+- Add `dependencies` property to client feature struct ([#30](https://github.com/unleash/unleash-types-rs/issues/30)) by @thomasheartman in #30
+
+
+### 💼 Other
+
+- Release unleash-types v0.10.5 by @thomasheartman
+
+- Release unleash-types v0.10.5 by @thomasheartman
+
+- Release unleash-types v0.10.5 by @thomasheartman
+
 
 ## [0.10.4] - 2023-07-14
 
 ### 🚀 Features
 
-- Add support for strategy variants ([#28](https://github.com/unleash/unleash-types-rs/issues/28))
+- Add support for strategy variants ([#28](https://github.com/unleash/unleash-types-rs/issues/28)) by @sighphyre in #28
+
+
+### 💼 Other
+
+- Release unleash-types v0.10.4 by @sighphyre
+
 
 ## [0.10.3] - 2023-06-28
 
+### 💼 Other
+
+- Release unleash-types v0.10.3 by @chriswk
+
+
 ### ⚙️ Miscellaneous Tasks
 
-- Cargo update
+- Cargo update by @chriswk
+
 
 ## [0.10.2] - 2023-06-28
 
 ### 🐛 Bug Fixes
 
-- Skip serializing if option is none ([#27](https://github.com/unleash/unleash-types-rs/issues/27))
+- Skip serializing if option is none ([#27](https://github.com/unleash/unleash-types-rs/issues/27)) in #27
+
+
+### 💼 Other
+
+- Release unleash-types v0.10.2 by @chriswk
+
 
 ## [0.10.1] - 2023-05-30
 
 ### 🐛 Bug Fixes
 
-- Patch ClientFeatures upsert behaviour to correctly take updated … ([#26](https://github.com/unleash/unleash-types-rs/issues/26))
+- Patch ClientFeatures upsert behaviour to correctly take updated … ([#26](https://github.com/unleash/unleash-types-rs/issues/26)) by @sighphyre in #26
+
+
+### 💼 Other
+
+- Release unleash-types v0.10.1 by @sighphyre
+
 
 ## [0.10.0] - 2023-04-18
 
 ### 🐛 Bug Fixes
 
-- Updated to not flatten properties map ([#25](https://github.com/unleash/unleash-types-rs/issues/25))
+- Updated to not flatten properties map ([#25](https://github.com/unleash/unleash-types-rs/issues/25)) in #25
+
+
+### 💼 Other
+
+- Release unleash-types v0.10.0 by @chriswk
+
 
 ## [0.9.4] - 2023-04-14
 
 ### 🐛 Bug Fixes
 
-- Gather unknown fields in Context into properties
+- Gather unknown fields in Context into properties by @chriswk
+
+
+### 💼 Other
+
+- Release unleash-types v0.9.4 by @chriswk
+
 
 ## [0.9.3] - 2023-04-14
 
 ### 🐛 Bug Fixes
 
-- Make properties an object in OpenAPI
+- Make properties an object in OpenAPI by @chriswk
+
+
+### 💼 Other
+
+- Release unleash-types v0.9.3 by @chriswk
+
 
 ## [0.9.2] - 2023-04-14
 
 ### 🚀 Features
 
-- Openapi intoparam details for properties field
+- Openapi intoparam details for properties field by @chriswk
+
+
+### 💼 Other
+
+- Release unleash-types v0.9.2 by @chriswk
+
 
 ## [0.9.1] - 2023-03-08
 
 ### 🚀 Features
 
-- Make EvaluatedToggle cloneable
+- Make EvaluatedToggle cloneable by @chriswk
+
+
+### 💼 Other
+
+- Create LICENSE by @sighphyre
+
+- Release unleash-types v0.9.1 by @chriswk
+
 
 ## [0.9.0] - 2023-03-02
 
 ### 🚀 Features
 
-- Adds an upsert method that prioritizes new incoming data ([#24](https://github.com/unleash/unleash-types-rs/issues/24))
+- Adds an upsert method that prioritizes new incoming data ([#24](https://github.com/unleash/unleash-types-rs/issues/24)) in #24
+
+
+### 💼 Other
+
+- Release unleash-types v0.9.0
+
 
 ### ⚙️ Miscellaneous Tasks
 
-- Use u32 and camelCase ([#23](https://github.com/unleash/unleash-types-rs/issues/23))
+- Use u32 and camelCase ([#23](https://github.com/unleash/unleash-types-rs/issues/23)) by @gastonfournier in #23
+
 
 ## [0.8.3] - 2023-02-13
 
 ### 🚀 Features
 
-- Derive IntoParams for Query and Context
+- Derive IntoParams for Query and Context by @chriswk
+
+
+### 💼 Other
+
+- Release unleash-types v0.8.3 by @chriswk
+
+- Release unleash-types v0.8.3 by @chriswk
+
 
 ### ⚙️ Miscellaneous Tasks
 
-- U64 might require special treatment ([#21](https://github.com/unleash/unleash-types-rs/issues/21))
+- U64 might require special treatment ([#21](https://github.com/unleash/unleash-types-rs/issues/21)) by @gastonfournier in #21
+
 
 ## [0.8.2] - 2023-02-09
 
 ### 🚀 Features
 
-- Implements a few sugar traits for working with the underlying domain specific vecs types - deduplicate and merge ([#20](https://github.com/unleash/unleash-types-rs/issues/20))
+- Implements a few sugar traits for working with the underlying domain specific vecs types - deduplicate and merge ([#20](https://github.com/unleash/unleash-types-rs/issues/20)) by @sighphyre in #20
+
 
 ### 🐛 Bug Fixes
 
-- Handle legacy metrics format ([#17](https://github.com/unleash/unleash-types-rs/issues/17))
+- Handle legacy metrics format ([#17](https://github.com/unleash/unleash-types-rs/issues/17)) by @sighphyre in #17
+
+
+### 💼 Other
+
+- Release unleash-types v0.8.1 ([#19](https://github.com/unleash/unleash-types-rs/issues/19)) by @sighphyre in #19
+
+- Release unleash-types v0.8.2
+
 
 ### ⚙️ Miscellaneous Tasks
 
-- Bump version to 0.8.1 ([#18](https://github.com/unleash/unleash-types-rs/issues/18))
+- Bump version to 0.8.1 ([#18](https://github.com/unleash/unleash-types-rs/issues/18)) by @sighphyre in #18
+
 
 ## [0.8.0] - 2023-02-07
 
 ### 🚀 Features
 
-- Add logic for batching metrics ([#14](https://github.com/unleash/unleash-types-rs/issues/14))
+- Add logic for batching metrics ([#14](https://github.com/unleash/unleash-types-rs/issues/14)) by @sighphyre in #14
+
 
 ### ⚙️ Miscellaneous Tasks
 
-- Bump version to v0.8.0 ([#15](https://github.com/unleash/unleash-types-rs/issues/15))
+- Bump version to v0.8.0 ([#15](https://github.com/unleash/unleash-types-rs/issues/15)) by @nunogois in #15
+
 
 ## [0.7.1] - 2023-02-01
 
@@ -162,48 +305,90 @@ All notable changes to this project will be documented in this file.
 
 - Use BASE64_URL_SAFE to hash client_features
 
+
+### 💼 Other
+
+- Release unleash-types v0.7.1
+
+
 ## [0.7.0] - 2023-01-27
 
 ### 🚀 Features
 
-- Deterministic serialization ([#13](https://github.com/unleash/unleash-types-rs/issues/13))
+- Deterministic serialization ([#13](https://github.com/unleash/unleash-types-rs/issues/13)) in #13
+
+
+### 💼 Other
+
+- Release unleash-types v0.7.0
+
 
 ## [0.6.0] - 2023-01-26
 
 ### 🚀 Features
 
-- Add openapi feature adding utoipa ToSchema ([#12](https://github.com/unleash/unleash-types-rs/issues/12))
+- Add openapi feature adding utoipa ToSchema ([#12](https://github.com/unleash/unleash-types-rs/issues/12)) in #12
+
+
+### 💼 Other
+
+- Release unleash-types v0.6.0
+
 
 ## [0.5.1] - 2023-01-24
 
 ### 🚀 Features
 
-- Add a default implementation for Context struct ([#11](https://github.com/unleash/unleash-types-rs/issues/11))
+- Add a default implementation for Context struct ([#11](https://github.com/unleash/unleash-types-rs/issues/11)) by @sighphyre in #11
+
+
+### 💼 Other
+
+- Release unleash-types v0.5.1
+
 
 ## [0.5.0] - 2023-01-24
 
 ### 🚀 Features
 
-- Add Context struct ([#10](https://github.com/unleash/unleash-types-rs/issues/10))
+- Add Context struct ([#10](https://github.com/unleash/unleash-types-rs/issues/10)) by @sighphyre in #10
+
+
+### 💼 Other
+
+- Release unleash-types v0.5.0
+
 
 ## [0.4.1] - 2023-01-20
 
 ### 🐛 Bug Fixes
 
-- Setup weight type to handle lowercased variants of the enum ([#7](https://github.com/unleash/unleash-types-rs/issues/7))
+- Setup weight type to handle lowercased variants of the enum ([#7](https://github.com/unleash/unleash-types-rs/issues/7)) in #7
+
 
 ### 💼 Other
 
-- Updated parameters to cargo-smart-release ([#8](https://github.com/unleash/unleash-types-rs/issues/8))
+- Updated parameters to cargo-smart-release ([#8](https://github.com/unleash/unleash-types-rs/issues/8)) in #8
+
+- Release unleash-types v0.4.1
+
+- Release unleash-types v0.4.1
+
 
 ### ⚙️ Miscellaneous Tasks
 
-- Add workflows for testcoverage and release ([#5](https://github.com/unleash/unleash-types-rs/issues/5))
-- Try to use rust-cache instead of github cache action ([#6](https://github.com/unleash/unleash-types-rs/issues/6))
+- Add workflows for testcoverage and release ([#5](https://github.com/unleash/unleash-types-rs/issues/5)) in #5
+
+- Try to use rust-cache instead of github cache action ([#6](https://github.com/unleash/unleash-types-rs/issues/6)) in #6
+
 - Fix typo in workflow
+
 - Only run codequality and test-coverage when rust,toml or the workflow has changed
+
 - Fetch the full repo and cache on failure
-- Use correct property for git fetch depth in build ([#9](https://github.com/unleash/unleash-types-rs/issues/9))
+
+- Use correct property for git fetch depth in build ([#9](https://github.com/unleash/unleash-types-rs/issues/9)) by @sighphyre in #9
+
 
 ## [0.4.0] - 2023-01-18
 
@@ -211,32 +396,55 @@ All notable changes to this project will be documented in this file.
 
 - Add structs for ClientMetrics
 
+
 ### 🐛 Bug Fixes
 
-- Remove unnecessary .into call ([#2](https://github.com/unleash/unleash-types-rs/issues/2))
+- Remove unnecessary .into call ([#2](https://github.com/unleash/unleash-types-rs/issues/2)) in #2
+
 
 ### 💼 Other
 
-- Add README ([#4](https://github.com/unleash/unleash-types-rs/issues/4))
+- Add README ([#4](https://github.com/unleash/unleash-types-rs/issues/4)) in #4
+
+- Release unleash-types v0.4.0
+
+- Release unleash-types v0.4.0
+
 
 ### ⚙️ Miscellaneous Tasks
 
 - Updated repo links after transferring ownership
+
 - Add -rs suffix
-- Add workflow for clippy and testing ([#1](https://github.com/unleash/unleash-types-rs/issues/1))
+
+- Add workflow for clippy and testing ([#1](https://github.com/unleash/unleash-types-rs/issues/1)) in #1
+
 - Add CHANGELOG
 
+
 ## [0.3.0] - 2022-12-21
+
+### 💼 Other
+
+- Added type for frontend results
+
 
 ### ⚙️ Miscellaneous Tasks
 
 - Release unleash-types version 0.3.0
 
+
 ## [0.2.1] - 2022-11-24
+
+### 💼 Other
+
+- Patch constraint operators to correctly handle StrEndsWith and unknown cases by @sighphyre
+
 
 ### ⚙️ Miscellaneous Tasks
 
-- Release unleash-types version 0.2.1
+- Release unleash-types version 0.2.1 by @sighphyre
+
 
 ## [0.2.0] - 2022-11-22
 
@@ -244,8 +452,25 @@ All notable changes to this project will be documented in this file.
 
 - Move client_features to separate mod
 
+- Bump version
+
+- Revert "bump version"
+
+
 ### ⚙️ Miscellaneous Tasks
 
 - Release unleash-types version 0.2.0
+
+
+## [0.1.0] - 2022-11-22
+
+### 💼 Other
+
+- Initial work with types from Client API response
+
+- Start working with tests
+
+- Add tests for deserialization by @sighphyre
+
 
 <!-- generated by git-cliff -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,1020 +2,250 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [0.15.0] - 2025-01-03
 
-## v0.15.0 (2025-01-03)
+### 🚀 Features
 
-### New Features
+- Derives the hash impl for query ([#43](https://github.com/unleash/unleash-types-rs/issues/43))
 
- - <csr-id-aaf14c8076bee3a2d8c95f6611c8271a8d1d7a8b/> derives the hash impl for query
+## [0.14.0] - 2024-10-18
 
-### Commit Statistics
+### ⚙️ Miscellaneous Tasks
 
-<csr-read-only-do-not-edit/>
+- Dependency maintenance ([#42](https://github.com/unleash/unleash-types-rs/issues/42))
 
- - 2 commits contributed to the release over the course of 2 calendar days.
- - 55 days passed between releases.
- - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
- - 2 unique issues were worked on: [#33](https://github.com/Unleash/unleash-types-rs/issues/33), [#43](https://github.com/Unleash/unleash-types-rs/issues/43)
+## [0.13.0] - 2024-07-19
 
-### Commit Details
+### 🚀 Features
 
-<csr-read-only-do-not-edit/>
+- Extend metrics and registration with optional metadata ([#40](https://github.com/unleash/unleash-types-rs/issues/40))
 
-<details><summary>view details</summary>
+### 🐛 Bug Fixes
 
- * **[#33](https://github.com/Unleash/unleash-types-rs/issues/33)**
-    - Clippy --fix ([`29754d5`](https://github.com/Unleash/unleash-types-rs/commit/29754d574e1e6207714278106aeb390263758a70))
- * **[#43](https://github.com/Unleash/unleash-types-rs/issues/43)**
-    - Derives the hash impl for query ([`aaf14c8`](https://github.com/Unleash/unleash-types-rs/commit/aaf14c8076bee3a2d8c95f6611c8271a8d1d7a8b))
-</details>
+- Re-add snake-case of impression_data ([#41](https://github.com/unleash/unleash-types-rs/issues/41))
 
-## v0.14.0 (2024-10-18)
+### ⚙️ Miscellaneous Tasks
 
-<csr-id-ffd8650c4af5bb81de537441e656ccfed05e54e1/>
+- Clippy/cargo linting cleanups ([#38](https://github.com/unleash/unleash-types-rs/issues/38))
+- Change tests so that we can add fields to clientapplication without a lot of noise ([#39](https://github.com/unleash/unleash-types-rs/issues/39))
+- Chrono security bump
 
-### Chore
+## [0.12.0] - 2024-04-25
 
- - <csr-id-ffd8650c4af5bb81de537441e656ccfed05e54e1/> dependency maintenance
+### 🐛 Bug Fixes
 
-### Commit Statistics
+- Convert frontend responses to camel case ([#36](https://github.com/unleash/unleash-types-rs/issues/36))
 
-<csr-read-only-do-not-edit/>
+## [0.11.0] - 2024-01-23
 
- - 2 commits contributed to the release.
- - 91 days passed between releases.
- - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
- - 1 unique issue was worked on: [#42](https://github.com/Unleash/unleash-types-rs/issues/42)
+### 🐛 Bug Fixes
 
-### Commit Details
+- Add stickiness to strategy variants ([#34](https://github.com/unleash/unleash-types-rs/issues/34))
 
-<csr-read-only-do-not-edit/>
+## [0.10.6] - 2023-11-30
 
-<details><summary>view details</summary>
+### 🐛 Bug Fixes
 
- * **[#42](https://github.com/Unleash/unleash-types-rs/issues/42)**
-    - Dependency maintenance ([`ffd8650`](https://github.com/Unleash/unleash-types-rs/commit/ffd8650c4af5bb81de537441e656ccfed05e54e1))
- * **Uncategorized**
-    - Release unleash-types v0.14.0 ([`44a2b81`](https://github.com/Unleash/unleash-types-rs/commit/44a2b81cda950adf84b3da3be6d9be40484e7da1))
-</details>
+- None strategy variants should serialize as empty array ([#32](https://github.com/unleash/unleash-types-rs/issues/32))
 
-## v0.13.0 (2024-07-19)
+### ⚙️ Miscellaneous Tasks
 
-<csr-id-06b3b3d384ca432c3250b3d210caa2a58e69dc25/>
-<csr-id-29a3068af3f3569f9717a4627388989dab9d9b6a/>
-<csr-id-12fc7c01a46d937a4882ae63b1f8c5e9688f2acb/>
+- Release unleash-types version 0.10.6
 
-### Chore
+## [0.10.5] - 2023-10-12
 
- - <csr-id-06b3b3d384ca432c3250b3d210caa2a58e69dc25/> chrono security bump
- - <csr-id-29a3068af3f3569f9717a4627388989dab9d9b6a/> change tests so that we can add fields to clientapplication without a lot of noise
- - <csr-id-12fc7c01a46d937a4882ae63b1f8c5e9688f2acb/> clippy/cargo linting cleanups
+### 🚀 Features
 
-### New Features
+- Add `dependencies` property to client feature struct ([#30](https://github.com/unleash/unleash-types-rs/issues/30))
 
- - <csr-id-993866059d3b5ca5733821768f86c2904e90b672/> extend metrics and registration with optional metadata
+## [0.10.4] - 2023-07-14
 
-### Bug Fixes
+### 🚀 Features
 
- - <csr-id-4f8ed4928db21f772fac51d9dbe46363a2e70a4c/> re-add snake-case of impression_data
+- Add support for strategy variants ([#28](https://github.com/unleash/unleash-types-rs/issues/28))
 
-### Commit Statistics
+## [0.10.3] - 2023-06-28
 
-<csr-read-only-do-not-edit/>
+### ⚙️ Miscellaneous Tasks
 
- - 6 commits contributed to the release.
- - 84 days passed between releases.
- - 5 commits were understood as [conventional](https://www.conventionalcommits.org).
- - 4 unique issues were worked on: [#38](https://github.com/Unleash/unleash-types-rs/issues/38), [#39](https://github.com/Unleash/unleash-types-rs/issues/39), [#40](https://github.com/Unleash/unleash-types-rs/issues/40), [#41](https://github.com/Unleash/unleash-types-rs/issues/41)
+- Cargo update
 
-### Commit Details
+## [0.10.2] - 2023-06-28
 
-<csr-read-only-do-not-edit/>
+### 🐛 Bug Fixes
 
-<details><summary>view details</summary>
+- Skip serializing if option is none ([#27](https://github.com/unleash/unleash-types-rs/issues/27))
 
- * **[#38](https://github.com/Unleash/unleash-types-rs/issues/38)**
-    - Clippy/cargo linting cleanups ([`12fc7c0`](https://github.com/Unleash/unleash-types-rs/commit/12fc7c01a46d937a4882ae63b1f8c5e9688f2acb))
- * **[#39](https://github.com/Unleash/unleash-types-rs/issues/39)**
-    - Change tests so that we can add fields to clientapplication without a lot of noise ([`29a3068`](https://github.com/Unleash/unleash-types-rs/commit/29a3068af3f3569f9717a4627388989dab9d9b6a))
- * **[#40](https://github.com/Unleash/unleash-types-rs/issues/40)**
-    - Extend metrics and registration with optional metadata ([`9938660`](https://github.com/Unleash/unleash-types-rs/commit/993866059d3b5ca5733821768f86c2904e90b672))
- * **[#41](https://github.com/Unleash/unleash-types-rs/issues/41)**
-    - Re-add snake-case of impression_data ([`4f8ed49`](https://github.com/Unleash/unleash-types-rs/commit/4f8ed4928db21f772fac51d9dbe46363a2e70a4c))
- * **Uncategorized**
-    - Release unleash-types v0.13.0 ([`8860ba2`](https://github.com/Unleash/unleash-types-rs/commit/8860ba2f7e3a5525bc91543177a6aaf73c90e46c))
-    - Chrono security bump ([`06b3b3d`](https://github.com/Unleash/unleash-types-rs/commit/06b3b3d384ca432c3250b3d210caa2a58e69dc25))
-</details>
+## [0.10.1] - 2023-05-30
 
-## v0.12.0 (2024-04-25)
+### 🐛 Bug Fixes
 
-### Bug Fixes
+- Patch ClientFeatures upsert behaviour to correctly take updated … ([#26](https://github.com/unleash/unleash-types-rs/issues/26))
 
- - <csr-id-1717a61b1eb7c29f6a902e30c921f29dca3bc95b/> convert frontend responses to camel case
+## [0.10.0] - 2023-04-18
 
-### Commit Statistics
+### 🐛 Bug Fixes
 
-<csr-read-only-do-not-edit/>
+- Updated to not flatten properties map ([#25](https://github.com/unleash/unleash-types-rs/issues/25))
 
- - 2 commits contributed to the release.
- - 92 days passed between releases.
- - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
- - 1 unique issue was worked on: [#36](https://github.com/Unleash/unleash-types-rs/issues/36)
+## [0.9.4] - 2023-04-14
 
-### Commit Details
+### 🐛 Bug Fixes
 
-<csr-read-only-do-not-edit/>
+- Gather unknown fields in Context into properties
 
-<details><summary>view details</summary>
+## [0.9.3] - 2023-04-14
 
- * **[#36](https://github.com/Unleash/unleash-types-rs/issues/36)**
-    - Convert frontend responses to camel case ([`1717a61`](https://github.com/Unleash/unleash-types-rs/commit/1717a61b1eb7c29f6a902e30c921f29dca3bc95b))
- * **Uncategorized**
-    - Release unleash-types v0.12.0 ([`ed9ad91`](https://github.com/Unleash/unleash-types-rs/commit/ed9ad9125d2866be33b2a88561851cdd5db35bb0))
-</details>
+### 🐛 Bug Fixes
 
-## v0.11.0 (2024-01-23)
+- Make properties an object in OpenAPI
 
-### Bug Fixes
+## [0.9.2] - 2023-04-14
 
- - <csr-id-9afeb15350d9167bcb1a9e82dee43bdb26e29f8c/> add stickiness to strategy variants
+### 🚀 Features
 
-### Commit Statistics
+- Openapi intoparam details for properties field
 
-<csr-read-only-do-not-edit/>
+## [0.9.1] - 2023-03-08
 
- - 2 commits contributed to the release.
- - 54 days passed between releases.
- - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
- - 1 unique issue was worked on: [#34](https://github.com/Unleash/unleash-types-rs/issues/34)
+### 🚀 Features
 
-### Commit Details
+- Make EvaluatedToggle cloneable
 
-<csr-read-only-do-not-edit/>
+## [0.9.0] - 2023-03-02
 
-<details><summary>view details</summary>
+### 🚀 Features
 
- * **[#34](https://github.com/Unleash/unleash-types-rs/issues/34)**
-    - Add stickiness to strategy variants ([`9afeb15`](https://github.com/Unleash/unleash-types-rs/commit/9afeb15350d9167bcb1a9e82dee43bdb26e29f8c))
- * **Uncategorized**
-    - Release unleash-types v0.11.0 ([`5645d74`](https://github.com/Unleash/unleash-types-rs/commit/5645d7425902c6298286884c1f4c9577b1bd370f))
-</details>
+- Adds an upsert method that prioritizes new incoming data ([#24](https://github.com/unleash/unleash-types-rs/issues/24))
 
-## v0.10.6 (2023-11-30)
+### ⚙️ Miscellaneous Tasks
 
-<csr-id-edf3920d67803952d7e8f1c604179375a5988844/>
+- Use u32 and camelCase ([#23](https://github.com/unleash/unleash-types-rs/issues/23))
 
-### Chore
+## [0.8.3] - 2023-02-13
 
- - <csr-id-edf3920d67803952d7e8f1c604179375a5988844/> Release unleash-types version 0.10.6
+### 🚀 Features
 
-### Bug Fixes
+- Derive IntoParams for Query and Context
 
- - <csr-id-dfadfc58aaef528332562bd1606e8d9b821c53f3/> none strategy variants should serialize as empty array
+### ⚙️ Miscellaneous Tasks
 
-### Commit Statistics
+- U64 might require special treatment ([#21](https://github.com/unleash/unleash-types-rs/issues/21))
 
-<csr-read-only-do-not-edit/>
+## [0.8.2] - 2023-02-09
 
- - 2 commits contributed to the release.
- - 49 days passed between releases.
- - 2 commits were understood as [conventional](https://www.conventionalcommits.org).
- - 1 unique issue was worked on: [#32](https://github.com/Unleash/unleash-types-rs/issues/32)
+### 🚀 Features
 
-### Commit Details
+- Implements a few sugar traits for working with the underlying domain specific vecs types - deduplicate and merge ([#20](https://github.com/unleash/unleash-types-rs/issues/20))
 
-<csr-read-only-do-not-edit/>
+### 🐛 Bug Fixes
 
-<details><summary>view details</summary>
+- Handle legacy metrics format ([#17](https://github.com/unleash/unleash-types-rs/issues/17))
 
- * **[#32](https://github.com/Unleash/unleash-types-rs/issues/32)**
-    - None strategy variants should serialize as empty array ([`dfadfc5`](https://github.com/Unleash/unleash-types-rs/commit/dfadfc58aaef528332562bd1606e8d9b821c53f3))
- * **Uncategorized**
-    - Release unleash-types version 0.10.6 ([`edf3920`](https://github.com/Unleash/unleash-types-rs/commit/edf3920d67803952d7e8f1c604179375a5988844))
-</details>
+### ⚙️ Miscellaneous Tasks
 
-## v0.10.5 (2023-10-12)
+- Bump version to 0.8.1 ([#18](https://github.com/unleash/unleash-types-rs/issues/18))
 
-<csr-id-fd005f9d91bb2b2b2b7095136bea165c653814b1/>
+## [0.8.0] - 2023-02-07
 
-### Chore
+### 🚀 Features
 
- - <csr-id-fd005f9d91bb2b2b2b7095136bea165c653814b1/> Bumps utoipa to new major version
+- Add logic for batching metrics ([#14](https://github.com/unleash/unleash-types-rs/issues/14))
 
-### New Features
+### ⚙️ Miscellaneous Tasks
 
- - <csr-id-573d86d96366a9500fbbd297ec40e607902d1eb4/> add `dependencies` property to client feature struct
-   ## Description
-   
-   
-   This change adds the dependencies property to the client feature
-   struct, opening the path for dependent feature toggles:
-   
-   Unleash/unleash#2255
-   
-   ## Commits
-   
-   * feat: add `dependencies` property to client feature struct
+- Bump version to v0.8.0 ([#15](https://github.com/unleash/unleash-types-rs/issues/15))
 
-### Commit Statistics
+## [0.7.1] - 2023-02-01
 
-<csr-read-only-do-not-edit/>
+### 🐛 Bug Fixes
 
- - 5 commits contributed to the release.
- - 89 days passed between releases.
- - 2 commits were understood as [conventional](https://www.conventionalcommits.org).
- - 2 unique issues were worked on: [#30](https://github.com/Unleash/unleash-types-rs/issues/30), [#31](https://github.com/Unleash/unleash-types-rs/issues/31)
+- Use BASE64_URL_SAFE to hash client_features
 
-### Commit Details
+## [0.7.0] - 2023-01-27
 
-<csr-read-only-do-not-edit/>
+### 🚀 Features
 
-<details><summary>view details</summary>
+- Deterministic serialization ([#13](https://github.com/unleash/unleash-types-rs/issues/13))
 
- * **[#30](https://github.com/Unleash/unleash-types-rs/issues/30)**
-    - Add `dependencies` property to client feature struct ([`573d86d`](https://github.com/Unleash/unleash-types-rs/commit/573d86d96366a9500fbbd297ec40e607902d1eb4))
- * **[#31](https://github.com/Unleash/unleash-types-rs/issues/31)**
-    - Bumps utoipa to new major version ([`fd005f9`](https://github.com/Unleash/unleash-types-rs/commit/fd005f9d91bb2b2b2b7095136bea165c653814b1))
- * **Uncategorized**
-    - Release unleash-types v0.10.5 ([`0e4303f`](https://github.com/Unleash/unleash-types-rs/commit/0e4303f2c3bd1cbebb9d5d46d100e957ad0f10c7))
-    - Release unleash-types v0.10.5 ([`90cd590`](https://github.com/Unleash/unleash-types-rs/commit/90cd590df9d53af5da8832bad0d8ae0273c9bcf1))
-    - Release unleash-types v0.10.5 ([`f96028e`](https://github.com/Unleash/unleash-types-rs/commit/f96028ec74e697915a9b7f7c0863babba79e7b92))
-</details>
+## [0.6.0] - 2023-01-26
 
-## v0.10.4 (2023-07-14)
+### 🚀 Features
 
-### New Features
+- Add openapi feature adding utoipa ToSchema ([#12](https://github.com/unleash/unleash-types-rs/issues/12))
 
- - <csr-id-0649b25ae53f61e0d5a383d6f58d9744f9c4494e/> add support for strategy variants
-   * feat: add support for strategy variants
+## [0.5.1] - 2023-01-24
 
-### Commit Statistics
+### 🚀 Features
 
-<csr-read-only-do-not-edit/>
+- Add a default implementation for Context struct ([#11](https://github.com/unleash/unleash-types-rs/issues/11))
 
- - 2 commits contributed to the release.
- - 15 days passed between releases.
- - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
- - 1 unique issue was worked on: [#28](https://github.com/Unleash/unleash-types-rs/issues/28)
+## [0.5.0] - 2023-01-24
 
-### Commit Details
+### 🚀 Features
 
-<csr-read-only-do-not-edit/>
+- Add Context struct ([#10](https://github.com/unleash/unleash-types-rs/issues/10))
 
-<details><summary>view details</summary>
+## [0.4.1] - 2023-01-20
 
- * **[#28](https://github.com/Unleash/unleash-types-rs/issues/28)**
-    - Add support for strategy variants ([`0649b25`](https://github.com/Unleash/unleash-types-rs/commit/0649b25ae53f61e0d5a383d6f58d9744f9c4494e))
- * **Uncategorized**
-    - Release unleash-types v0.10.4 ([`aa5b7cc`](https://github.com/Unleash/unleash-types-rs/commit/aa5b7cc0f899cad6e57c7457e22ca72207fe49d8))
-</details>
+### 🐛 Bug Fixes
 
-## v0.10.3 (2023-06-28)
+- Setup weight type to handle lowercased variants of the enum ([#7](https://github.com/unleash/unleash-types-rs/issues/7))
 
-<csr-id-a5ae89ee2994e36c0a9149916b5b2a7846dd2025/>
+### 💼 Other
 
-### Chore
+- Updated parameters to cargo-smart-release ([#8](https://github.com/unleash/unleash-types-rs/issues/8))
 
- - <csr-id-a5ae89ee2994e36c0a9149916b5b2a7846dd2025/> cargo update
+### ⚙️ Miscellaneous Tasks
 
-### Commit Statistics
+- Add workflows for testcoverage and release ([#5](https://github.com/unleash/unleash-types-rs/issues/5))
+- Try to use rust-cache instead of github cache action ([#6](https://github.com/unleash/unleash-types-rs/issues/6))
+- Fix typo in workflow
+- Only run codequality and test-coverage when rust,toml or the workflow has changed
+- Fetch the full repo and cache on failure
+- Use correct property for git fetch depth in build ([#9](https://github.com/unleash/unleash-types-rs/issues/9))
 
-<csr-read-only-do-not-edit/>
+## [0.4.0] - 2023-01-18
 
- - 2 commits contributed to the release.
- - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
- - 0 issues like '(#ID)' were seen in commit messages
+### 🚀 Features
 
-### Commit Details
+- Add structs for ClientMetrics
 
-<csr-read-only-do-not-edit/>
+### 🐛 Bug Fixes
 
-<details><summary>view details</summary>
+- Remove unnecessary .into call ([#2](https://github.com/unleash/unleash-types-rs/issues/2))
 
- * **Uncategorized**
-    - Release unleash-types v0.10.3 ([`85622d9`](https://github.com/Unleash/unleash-types-rs/commit/85622d9a8eda9bb419b3dedea4236bb599051606))
-    - Cargo update ([`a5ae89e`](https://github.com/Unleash/unleash-types-rs/commit/a5ae89ee2994e36c0a9149916b5b2a7846dd2025))
-</details>
+### 💼 Other
 
-## v0.10.2 (2023-06-28)
+- Add README ([#4](https://github.com/unleash/unleash-types-rs/issues/4))
 
-### Bug Fixes
+### ⚙️ Miscellaneous Tasks
 
- - <csr-id-2af300839432434ffad713f28dd33986e14928da/> Skip serializing if option is none
+- Updated repo links after transferring ownership
+- Add -rs suffix
+- Add workflow for clippy and testing ([#1](https://github.com/unleash/unleash-types-rs/issues/1))
+- Add CHANGELOG
 
-### Commit Statistics
+## [0.3.0] - 2022-12-21
 
-<csr-read-only-do-not-edit/>
+### ⚙️ Miscellaneous Tasks
 
- - 2 commits contributed to the release.
- - 29 days passed between releases.
- - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
- - 1 unique issue was worked on: [#27](https://github.com/Unleash/unleash-types-rs/issues/27)
+- Release unleash-types version 0.3.0
 
-### Commit Details
+## [0.2.1] - 2022-11-24
 
-<csr-read-only-do-not-edit/>
+### ⚙️ Miscellaneous Tasks
 
-<details><summary>view details</summary>
+- Release unleash-types version 0.2.1
 
- * **[#27](https://github.com/Unleash/unleash-types-rs/issues/27)**
-    - Skip serializing if option is none ([`2af3008`](https://github.com/Unleash/unleash-types-rs/commit/2af300839432434ffad713f28dd33986e14928da))
- * **Uncategorized**
-    - Release unleash-types v0.10.2 ([`5be22b3`](https://github.com/Unleash/unleash-types-rs/commit/5be22b3ca17d8815b016a12dfec840454bd96cb6))
-</details>
+## [0.2.0] - 2022-11-22
 
-## v0.10.1 (2023-05-30)
+### 💼 Other
 
-### Bug Fixes
+- Move client_features to separate mod
 
- - <csr-id-1cd7287e77576e86106a182ebdf57660161544fa/> patch ClientFeatures upsert behaviour to correctly take updated …
-   * fix: patch ClientFeatures upsert behaviour to correctly take updated segment
+### ⚙️ Miscellaneous Tasks
 
-### Commit Statistics
+- Release unleash-types version 0.2.0
 
-<csr-read-only-do-not-edit/>
-
- - 2 commits contributed to the release.
- - 41 days passed between releases.
- - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
- - 1 unique issue was worked on: [#26](https://github.com/Unleash/unleash-types-rs/issues/26)
-
-### Commit Details
-
-<csr-read-only-do-not-edit/>
-
-<details><summary>view details</summary>
-
- * **[#26](https://github.com/Unleash/unleash-types-rs/issues/26)**
-    - Patch ClientFeatures upsert behaviour to correctly take updated … ([`1cd7287`](https://github.com/Unleash/unleash-types-rs/commit/1cd7287e77576e86106a182ebdf57660161544fa))
- * **Uncategorized**
-    - Release unleash-types v0.10.1 ([`9946218`](https://github.com/Unleash/unleash-types-rs/commit/9946218487714001a5e1ccbeb234f4b80d4d7fda))
-</details>
-
-## v0.10.0 (2023-04-18)
-
-### Bug Fixes
-
- - <csr-id-22b2912072c2ba089516f54dbcbf39cba23c5979/> updated to not flatten properties map
-   Also declares IntoParams as belonging to Query, not to Path, to allow utoipa to build correct openAPI spec
-
-### Commit Statistics
-
-<csr-read-only-do-not-edit/>
-
- - 2 commits contributed to the release.
- - 4 days passed between releases.
- - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
- - 1 unique issue was worked on: [#25](https://github.com/Unleash/unleash-types-rs/issues/25)
-
-### Commit Details
-
-<csr-read-only-do-not-edit/>
-
-<details><summary>view details</summary>
-
- * **[#25](https://github.com/Unleash/unleash-types-rs/issues/25)**
-    - Updated to not flatten properties map ([`22b2912`](https://github.com/Unleash/unleash-types-rs/commit/22b2912072c2ba089516f54dbcbf39cba23c5979))
- * **Uncategorized**
-    - Release unleash-types v0.10.0 ([`da5901e`](https://github.com/Unleash/unleash-types-rs/commit/da5901e82a013516a791966cc70821e458413fa2))
-</details>
-
-## v0.9.4 (2023-04-14)
-
-### Bug Fixes
-
- - <csr-id-8b54b3c9f6466a0a5253a5132b92bf84e9e1c730/> gather unknown fields in Context into properties
-
-### Commit Statistics
-
-<csr-read-only-do-not-edit/>
-
- - 2 commits contributed to the release.
- - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
- - 0 issues like '(#ID)' were seen in commit messages
-
-### Commit Details
-
-<csr-read-only-do-not-edit/>
-
-<details><summary>view details</summary>
-
- * **Uncategorized**
-    - Release unleash-types v0.9.4 ([`c1843f1`](https://github.com/Unleash/unleash-types-rs/commit/c1843f16cb0d3343e3a51f38794b3ce7a7e932c7))
-    - Gather unknown fields in Context into properties ([`8b54b3c`](https://github.com/Unleash/unleash-types-rs/commit/8b54b3c9f6466a0a5253a5132b92bf84e9e1c730))
-</details>
-
-## v0.9.3 (2023-04-14)
-
-### Bug Fixes
-
- - <csr-id-2c3f514788a644fa0d8cd87cbd4fc2e191d1403e/> Make properties an object in OpenAPI
-
-### Commit Statistics
-
-<csr-read-only-do-not-edit/>
-
- - 2 commits contributed to the release.
- - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
- - 0 issues like '(#ID)' were seen in commit messages
-
-### Commit Details
-
-<csr-read-only-do-not-edit/>
-
-<details><summary>view details</summary>
-
- * **Uncategorized**
-    - Release unleash-types v0.9.3 ([`279931b`](https://github.com/Unleash/unleash-types-rs/commit/279931b6a6b4db6565c1ce1b725b4b056e4f1258))
-    - Make properties an object in OpenAPI ([`2c3f514`](https://github.com/Unleash/unleash-types-rs/commit/2c3f514788a644fa0d8cd87cbd4fc2e191d1403e))
-</details>
-
-## v0.9.2 (2023-04-14)
-
-### New Features
-
- - <csr-id-6b6bc4ddd7040d101894c98ace9971caf381f631/> openapi intoparam details for properties field
-
-### Commit Statistics
-
-<csr-read-only-do-not-edit/>
-
- - 2 commits contributed to the release.
- - 36 days passed between releases.
- - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
- - 0 issues like '(#ID)' were seen in commit messages
-
-### Commit Details
-
-<csr-read-only-do-not-edit/>
-
-<details><summary>view details</summary>
-
- * **Uncategorized**
-    - Release unleash-types v0.9.2 ([`773b815`](https://github.com/Unleash/unleash-types-rs/commit/773b815d54c0f74e56cf1ce6fdc3e57162522d0f))
-    - Openapi intoparam details for properties field ([`6b6bc4d`](https://github.com/Unleash/unleash-types-rs/commit/6b6bc4ddd7040d101894c98ace9971caf381f631))
-</details>
-
-## v0.9.1 (2023-03-08)
-
-### New Features
-
- - <csr-id-e787314d8b820eb00e011ec8033993deb07467c0/> Make EvaluatedToggle cloneable
-
-### Commit Statistics
-
-<csr-read-only-do-not-edit/>
-
- - 3 commits contributed to the release over the course of 6 calendar days.
- - 6 days passed between releases.
- - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
- - 0 issues like '(#ID)' were seen in commit messages
-
-### Commit Details
-
-<csr-read-only-do-not-edit/>
-
-<details><summary>view details</summary>
-
- * **Uncategorized**
-    - Release unleash-types v0.9.1 ([`7b51242`](https://github.com/Unleash/unleash-types-rs/commit/7b512429339623eab2a0b1e938cd82b844c4ac95))
-    - Make EvaluatedToggle cloneable ([`e787314`](https://github.com/Unleash/unleash-types-rs/commit/e787314d8b820eb00e011ec8033993deb07467c0))
-    - Create LICENSE ([`fae2e1c`](https://github.com/Unleash/unleash-types-rs/commit/fae2e1ce0ed8f427ea5ef1373aba564377f033db))
-</details>
-
-## v0.9.0 (2023-03-02)
-
-<csr-id-aa859b39d62ca4be054f45a4ba2729003c40c879/>
-
-### Chore
-
- - <csr-id-aa859b39d62ca4be054f45a4ba2729003c40c879/> use u32 and camelCase
-
-### New Features
-
- - <csr-id-03e87ed378db6ec486dc246c57f22ce49eddcb9f/> Adds an upsert method that prioritizes new incoming data
-
-### Commit Statistics
-
-<csr-read-only-do-not-edit/>
-
- - 3 commits contributed to the release over the course of 16 calendar days.
- - 16 days passed between releases.
- - 2 commits were understood as [conventional](https://www.conventionalcommits.org).
- - 2 unique issues were worked on: [#23](https://github.com/Unleash/unleash-types-rs/issues/23), [#24](https://github.com/Unleash/unleash-types-rs/issues/24)
-
-### Commit Details
-
-<csr-read-only-do-not-edit/>
-
-<details><summary>view details</summary>
-
- * **[#23](https://github.com/Unleash/unleash-types-rs/issues/23)**
-    - Use u32 and camelCase ([`aa859b3`](https://github.com/Unleash/unleash-types-rs/commit/aa859b39d62ca4be054f45a4ba2729003c40c879))
- * **[#24](https://github.com/Unleash/unleash-types-rs/issues/24)**
-    - Adds an upsert method that prioritizes new incoming data ([`03e87ed`](https://github.com/Unleash/unleash-types-rs/commit/03e87ed378db6ec486dc246c57f22ce49eddcb9f))
- * **Uncategorized**
-    - Release unleash-types v0.9.0 ([`d6a1a0f`](https://github.com/Unleash/unleash-types-rs/commit/d6a1a0fd286b1cdc31ea16c2b13eb9e801ee38ed))
-</details>
-
-## v0.8.3 (2023-02-13)
-
-<csr-id-f9e6f0ece28af409e8a52550c581e1030ebf81e5/>
-
-### Chore
-
- - <csr-id-f9e6f0ece28af409e8a52550c581e1030ebf81e5/> u64 might require special treatment
-
-### New Features
-
- - <csr-id-9d70f66674bac22ffbe77cf7108527827ce26206/> derive IntoParams for Query and Context
-
-### Commit Statistics
-
-<csr-read-only-do-not-edit/>
-
- - 4 commits contributed to the release over the course of 2 calendar days.
- - 3 days passed between releases.
- - 2 commits were understood as [conventional](https://www.conventionalcommits.org).
- - 1 unique issue was worked on: [#21](https://github.com/Unleash/unleash-types-rs/issues/21)
-
-### Commit Details
-
-<csr-read-only-do-not-edit/>
-
-<details><summary>view details</summary>
-
- * **[#21](https://github.com/Unleash/unleash-types-rs/issues/21)**
-    - U64 might require special treatment ([`f9e6f0e`](https://github.com/Unleash/unleash-types-rs/commit/f9e6f0ece28af409e8a52550c581e1030ebf81e5))
- * **Uncategorized**
-    - Release unleash-types v0.8.3 ([`f7a2ae7`](https://github.com/Unleash/unleash-types-rs/commit/f7a2ae7a848cfec1da4b73c7d2f5e375c5245c86))
-    - Release unleash-types v0.8.3 ([`cb0112b`](https://github.com/Unleash/unleash-types-rs/commit/cb0112b0d32c4ebcddbee665776e883bca909fcf))
-    - Derive IntoParams for Query and Context ([`9d70f66`](https://github.com/Unleash/unleash-types-rs/commit/9d70f66674bac22ffbe77cf7108527827ce26206))
-</details>
-
-## v0.8.2 (2023-02-09)
-
-<csr-id-8f07c238092ffe729ecc110abc12d389f70f26f7/>
-
-### Chore
-
- - <csr-id-8f07c238092ffe729ecc110abc12d389f70f26f7/> bump version to 0.8.1
-
-### New Features
-
- - <csr-id-1752d1881d41e346e7847b749f70b93767600923/> implements a few sugar traits for working with the underlying domain specific vecs types - deduplicate and merge
-
-### Bug Fixes
-
- - <csr-id-e4793a9f653c78bca55e63736cb94d210f72fa41/> handle legacy metrics format
-
-### Commit Statistics
-
-<csr-read-only-do-not-edit/>
-
- - 5 commits contributed to the release over the course of 1 calendar day.
- - 2 days passed between releases.
- - 3 commits were understood as [conventional](https://www.conventionalcommits.org).
- - 4 unique issues were worked on: [#17](https://github.com/Unleash/unleash-types-rs/issues/17), [#18](https://github.com/Unleash/unleash-types-rs/issues/18), [#19](https://github.com/Unleash/unleash-types-rs/issues/19), [#20](https://github.com/Unleash/unleash-types-rs/issues/20)
-
-### Commit Details
-
-<csr-read-only-do-not-edit/>
-
-<details><summary>view details</summary>
-
- * **[#17](https://github.com/Unleash/unleash-types-rs/issues/17)**
-    - Handle legacy metrics format ([`e4793a9`](https://github.com/Unleash/unleash-types-rs/commit/e4793a9f653c78bca55e63736cb94d210f72fa41))
- * **[#18](https://github.com/Unleash/unleash-types-rs/issues/18)**
-    - Bump version to 0.8.1 ([`8f07c23`](https://github.com/Unleash/unleash-types-rs/commit/8f07c238092ffe729ecc110abc12d389f70f26f7))
- * **[#19](https://github.com/Unleash/unleash-types-rs/issues/19)**
-    - Release unleash-types v0.8.1 ([`fe8cfa8`](https://github.com/Unleash/unleash-types-rs/commit/fe8cfa86cf5123f8401f8ae4dd2ce379b6cfe584))
- * **[#20](https://github.com/Unleash/unleash-types-rs/issues/20)**
-    - Implements a few sugar traits for working with the underlying domain specific vecs types - deduplicate and merge ([`1752d18`](https://github.com/Unleash/unleash-types-rs/commit/1752d1881d41e346e7847b749f70b93767600923))
- * **Uncategorized**
-    - Release unleash-types v0.8.2 ([`5bdddb7`](https://github.com/Unleash/unleash-types-rs/commit/5bdddb7b003328d10930039738bd992f7622f481))
-</details>
-
-## v0.8.1 (2023-02-09)
-
-<csr-id-8f07c238092ffe729ecc110abc12d389f70f26f7/>
-
-### Chore
-
- - <csr-id-8f07c238092ffe729ecc110abc12d389f70f26f7/> bump version to 0.8.1
-
-### New Features
-
- - <csr-id-1752d1881d41e346e7847b749f70b93767600923/> implements a few sugar traits for working with the underlying domain specific vecs types - deduplicate and merge
-
-### Bug Fixes
-
- - <csr-id-e4793a9f653c78bca55e63736cb94d210f72fa41/> handle legacy metrics format
-
-## v0.8.0 (2023-02-07)
-
-<csr-id-ff2837e50d7812b821949565cc4c00f44f37a8be/>
-
-### Chore
-
- - <csr-id-ff2837e50d7812b821949565cc4c00f44f37a8be/> bump version to v0.8.0
-
-### New Features
-
- - <csr-id-323b65caa87788b200325f67ba63c7c7ef966fd6/> add logic for batching metrics
-
-### Commit Statistics
-
-<csr-read-only-do-not-edit/>
-
- - 2 commits contributed to the release.
- - 6 days passed between releases.
- - 2 commits were understood as [conventional](https://www.conventionalcommits.org).
- - 2 unique issues were worked on: [#14](https://github.com/Unleash/unleash-types-rs/issues/14), [#15](https://github.com/Unleash/unleash-types-rs/issues/15)
-
-### Commit Details
-
-<csr-read-only-do-not-edit/>
-
-<details><summary>view details</summary>
-
- * **[#14](https://github.com/Unleash/unleash-types-rs/issues/14)**
-    - Add logic for batching metrics ([`323b65c`](https://github.com/Unleash/unleash-types-rs/commit/323b65caa87788b200325f67ba63c7c7ef966fd6))
- * **[#15](https://github.com/Unleash/unleash-types-rs/issues/15)**
-    - Bump version to v0.8.0 ([`ff2837e`](https://github.com/Unleash/unleash-types-rs/commit/ff2837e50d7812b821949565cc4c00f44f37a8be))
-</details>
-
-## v0.7.1 (2023-02-01)
-
-### Bug Fixes
-
- - <csr-id-12d3de2edaf3c182f747b60408441dc80a7a65df/> Use BASE64_URL_SAFE to hash client_features
-
-### Commit Statistics
-
-<csr-read-only-do-not-edit/>
-
- - 2 commits contributed to the release.
- - 5 days passed between releases.
- - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
- - 0 issues like '(#ID)' were seen in commit messages
-
-### Commit Details
-
-<csr-read-only-do-not-edit/>
-
-<details><summary>view details</summary>
-
- * **Uncategorized**
-    - Release unleash-types v0.7.1 ([`239488a`](https://github.com/Unleash/unleash-types-rs/commit/239488a030e9dd450464dbe377975085ad2cf5b9))
-    - Use BASE64_URL_SAFE to hash client_features ([`12d3de2`](https://github.com/Unleash/unleash-types-rs/commit/12d3de2edaf3c182f747b60408441dc80a7a65df))
-</details>
-
-## v0.7.0 (2023-01-27)
-
-### New Features
-
- - <csr-id-ac9da78eb2a58b78580308268f5ee9e79c67e5c2/> deterministic serialization
-   * task: make sure ClientFeatures to_str is deterministic
-* fix: Serialize maps as BTreeMaps
-* fix: variants should be ordered by name
-
-### Commit Statistics
-
-<csr-read-only-do-not-edit/>
-
- - 2 commits contributed to the release.
- - 1 day passed between releases.
- - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
- - 1 unique issue was worked on: [#13](https://github.com/Unleash/unleash-types-rs/issues/13)
-
-### Commit Details
-
-<csr-read-only-do-not-edit/>
-
-<details><summary>view details</summary>
-
- * **[#13](https://github.com/Unleash/unleash-types-rs/issues/13)**
-    - Deterministic serialization ([`ac9da78`](https://github.com/Unleash/unleash-types-rs/commit/ac9da78eb2a58b78580308268f5ee9e79c67e5c2))
- * **Uncategorized**
-    - Release unleash-types v0.7.0 ([`4587020`](https://github.com/Unleash/unleash-types-rs/commit/45870207ccf3f1d3630cd71f9c8388f512b0dfb8))
-</details>
-
-## v0.6.0 (2023-01-26)
-
-### New Features
-
- - <csr-id-387d1e27522b797e8d241d550cf2cef5ef5e1e83/> add openapi feature adding utoipa ToSchema
-
-### Commit Statistics
-
-<csr-read-only-do-not-edit/>
-
- - 2 commits contributed to the release.
- - 1 day passed between releases.
- - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
- - 1 unique issue was worked on: [#12](https://github.com/Unleash/unleash-types-rs/issues/12)
-
-### Commit Details
-
-<csr-read-only-do-not-edit/>
-
-<details><summary>view details</summary>
-
- * **[#12](https://github.com/Unleash/unleash-types-rs/issues/12)**
-    - Add openapi feature adding utoipa ToSchema ([`387d1e2`](https://github.com/Unleash/unleash-types-rs/commit/387d1e27522b797e8d241d550cf2cef5ef5e1e83))
- * **Uncategorized**
-    - Release unleash-types v0.6.0 ([`430059d`](https://github.com/Unleash/unleash-types-rs/commit/430059db169a18c70fe570fe5e11e165f398a713))
-</details>
-
-## v0.5.1 (2023-01-24)
-
-### New Features
-
- - <csr-id-9e6aa99a49d694a9348121f83bf38961b5f5eaeb/> add a default implementation for Context struct
-
-### Commit Statistics
-
-<csr-read-only-do-not-edit/>
-
- - 2 commits contributed to the release.
- - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
- - 1 unique issue was worked on: [#11](https://github.com/Unleash/unleash-types-rs/issues/11)
-
-### Commit Details
-
-<csr-read-only-do-not-edit/>
-
-<details><summary>view details</summary>
-
- * **[#11](https://github.com/Unleash/unleash-types-rs/issues/11)**
-    - Add a default implementation for Context struct ([`9e6aa99`](https://github.com/Unleash/unleash-types-rs/commit/9e6aa99a49d694a9348121f83bf38961b5f5eaeb))
- * **Uncategorized**
-    - Release unleash-types v0.5.1 ([`c251815`](https://github.com/Unleash/unleash-types-rs/commit/c251815a5072cfe3a3b9ac5ea3ce159a8ce95736))
-</details>
-
-## v0.5.0 (2023-01-24)
-
-### New Features
-
- - <csr-id-8ab0650d22051bba48d4b685e7d25d90722ec716/> Add Context struct
-   * feat: Add Context struct
-* chore: add test for context deserializing
-* feat: add serialize on context
-
-### Commit Statistics
-
-<csr-read-only-do-not-edit/>
-
- - 2 commits contributed to the release.
- - 4 days passed between releases.
- - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
- - 1 unique issue was worked on: [#10](https://github.com/Unleash/unleash-types-rs/issues/10)
-
-### Commit Details
-
-<csr-read-only-do-not-edit/>
-
-<details><summary>view details</summary>
-
- * **[#10](https://github.com/Unleash/unleash-types-rs/issues/10)**
-    - Add Context struct ([`8ab0650`](https://github.com/Unleash/unleash-types-rs/commit/8ab0650d22051bba48d4b685e7d25d90722ec716))
- * **Uncategorized**
-    - Release unleash-types v0.5.0 ([`f095fac`](https://github.com/Unleash/unleash-types-rs/commit/f095facd4199277d453206f79f5a26aa161f2324))
-</details>
-
-## v0.4.1 (2023-01-20)
-
-<csr-id-d8c299bef00283760126f1e37cea94242f369727/>
-<csr-id-9a47f754ab0e6025b41abde61bd00b457505c9fa/>
-<csr-id-34f471e18fa7f0ddd028b3a2ff56caf472061169/>
-<csr-id-96554d828eb4c7aaec898da7ada887d6b26cce85/>
-<csr-id-66f019c249fdfec4d6867971e916eb31325c81e5/>
-<csr-id-11027d0d82e6c83c9598b3f3beb5e8a1ecb3c0ac/>
-<csr-id-21a93f0cd88076e0a94941f05587b5ad5e15cf37/>
-
-### Chore
-
- - <csr-id-d8c299bef00283760126f1e37cea94242f369727/> use correct property for git fetch depth in build
- - <csr-id-9a47f754ab0e6025b41abde61bd00b457505c9fa/> fetch the full repo and cache on failure
- - <csr-id-34f471e18fa7f0ddd028b3a2ff56caf472061169/> only run codequality and test-coverage when rust,toml or the workflow has changed
- - <csr-id-96554d828eb4c7aaec898da7ada887d6b26cce85/> fix typo in workflow
- - <csr-id-66f019c249fdfec4d6867971e916eb31325c81e5/> Add workflows for testcoverage and release
-
-### Bug Fixes
-
- - <csr-id-040cf879382a59989c27dca9c5c938418879a4c3/> Setup weight type to handle lowercased variants of the enum
-
-### Other
-
- - <csr-id-11027d0d82e6c83c9598b3f3beb5e8a1ecb3c0ac/> updated parameters to cargo-smart-release
- - <csr-id-21a93f0cd88076e0a94941f05587b5ad5e15cf37/> try to use rust-cache instead of github cache action
-
-### Commit Statistics
-
-<csr-read-only-do-not-edit/>
-
- - 10 commits contributed to the release over the course of 1 calendar day.
- - 1 day passed between releases.
- - 8 commits were understood as [conventional](https://www.conventionalcommits.org).
- - 5 unique issues were worked on: [#5](https://github.com/Unleash/unleash-types-rs/issues/5), [#6](https://github.com/Unleash/unleash-types-rs/issues/6), [#7](https://github.com/Unleash/unleash-types-rs/issues/7), [#8](https://github.com/Unleash/unleash-types-rs/issues/8), [#9](https://github.com/Unleash/unleash-types-rs/issues/9)
-
-### Commit Details
-
-<csr-read-only-do-not-edit/>
-
-<details><summary>view details</summary>
-
- * **[#5](https://github.com/Unleash/unleash-types-rs/issues/5)**
-    - Add workflows for testcoverage and release ([`66f019c`](https://github.com/Unleash/unleash-types-rs/commit/66f019c249fdfec4d6867971e916eb31325c81e5))
- * **[#6](https://github.com/Unleash/unleash-types-rs/issues/6)**
-    - Try to use rust-cache instead of github cache action ([`21a93f0`](https://github.com/Unleash/unleash-types-rs/commit/21a93f0cd88076e0a94941f05587b5ad5e15cf37))
- * **[#7](https://github.com/Unleash/unleash-types-rs/issues/7)**
-    - Setup weight type to handle lowercased variants of the enum ([`040cf87`](https://github.com/Unleash/unleash-types-rs/commit/040cf879382a59989c27dca9c5c938418879a4c3))
- * **[#8](https://github.com/Unleash/unleash-types-rs/issues/8)**
-    - Updated parameters to cargo-smart-release ([`11027d0`](https://github.com/Unleash/unleash-types-rs/commit/11027d0d82e6c83c9598b3f3beb5e8a1ecb3c0ac))
- * **[#9](https://github.com/Unleash/unleash-types-rs/issues/9)**
-    - Use correct property for git fetch depth in build ([`d8c299b`](https://github.com/Unleash/unleash-types-rs/commit/d8c299bef00283760126f1e37cea94242f369727))
- * **Uncategorized**
-    - Release unleash-types v0.4.1 ([`8339c42`](https://github.com/Unleash/unleash-types-rs/commit/8339c42b99a3223a832586defd54347a59385d02))
-    - Release unleash-types v0.4.1 ([`f6d59de`](https://github.com/Unleash/unleash-types-rs/commit/f6d59dee03a61f838a438a1fa522c9f202908709))
-    - Fetch the full repo and cache on failure ([`9a47f75`](https://github.com/Unleash/unleash-types-rs/commit/9a47f754ab0e6025b41abde61bd00b457505c9fa))
-    - Only run codequality and test-coverage when rust,toml or the workflow has changed ([`34f471e`](https://github.com/Unleash/unleash-types-rs/commit/34f471e18fa7f0ddd028b3a2ff56caf472061169))
-    - Fix typo in workflow ([`96554d8`](https://github.com/Unleash/unleash-types-rs/commit/96554d828eb4c7aaec898da7ada887d6b26cce85))
-</details>
-
-## v0.4.0 (2023-01-18)
-
-<csr-id-6a91af13c2d1a107e9f7260e2af5ec9f26294a4d/>
-<csr-id-0a251eaa2bcfec307df4b6aef1dcda28ec8a9838/>
-<csr-id-48f001e044f058cdce0bfa07fe7c839c7f37748b/>
-<csr-id-2f4dde564fa4822bb86fd7c395de6da1b1babde3/>
-<csr-id-406c9fd5bbaa11f79d47e1cbe95f641a987922b2/>
-
-### Chore
-
- - <csr-id-6a91af13c2d1a107e9f7260e2af5ec9f26294a4d/> Add workflow for clippy and testing
- - <csr-id-0a251eaa2bcfec307df4b6aef1dcda28ec8a9838/> add -rs suffix
- - <csr-id-48f001e044f058cdce0bfa07fe7c839c7f37748b/> Updated repo links after transferring ownership
-
-### Chore
-
- - <csr-id-406c9fd5bbaa11f79d47e1cbe95f641a987922b2/> Add CHANGELOG
-
-### New Features
-
- - <csr-id-47a1cfec6023e4bb18a61142c69c771e5ca78bef/> Add structs for ClientMetrics
-   Added structs with helper methods allowing us to increment enabled/disabled occurrences of toggles.
-
-### Bug Fixes
-
- - <csr-id-85f8a586de7ffd9542fb0f5c949825c271718956/> Remove unnecessary .into call
-
-### Other
-
- - <csr-id-2f4dde564fa4822bb86fd7c395de6da1b1babde3/> add README
-
-### Commit Statistics
-
-<csr-read-only-do-not-edit/>
-
- - 9 commits contributed to the release over the course of 2 calendar days.
- - 28 days passed between releases.
- - 7 commits were understood as [conventional](https://www.conventionalcommits.org).
- - 3 unique issues were worked on: [#1](https://github.com/Unleash/unleash-types-rs/issues/1), [#2](https://github.com/Unleash/unleash-types-rs/issues/2), [#4](https://github.com/Unleash/unleash-types-rs/issues/4)
-
-### Commit Details
-
-<csr-read-only-do-not-edit/>
-
-<details><summary>view details</summary>
-
- * **[#1](https://github.com/Unleash/unleash-types-rs/issues/1)**
-    - Add workflow for clippy and testing ([`6a91af1`](https://github.com/Unleash/unleash-types-rs/commit/6a91af13c2d1a107e9f7260e2af5ec9f26294a4d))
- * **[#2](https://github.com/Unleash/unleash-types-rs/issues/2)**
-    - Remove unnecessary .into call ([`85f8a58`](https://github.com/Unleash/unleash-types-rs/commit/85f8a586de7ffd9542fb0f5c949825c271718956))
- * **[#4](https://github.com/Unleash/unleash-types-rs/issues/4)**
-    - Add README ([`2f4dde5`](https://github.com/Unleash/unleash-types-rs/commit/2f4dde564fa4822bb86fd7c395de6da1b1babde3))
- * **Uncategorized**
-    - Release unleash-types v0.4.0 ([`cac15d9`](https://github.com/Unleash/unleash-types-rs/commit/cac15d93e19878884c0d83e8d7a54603bc50db0c))
-    - Add CHANGELOG ([`406c9fd`](https://github.com/Unleash/unleash-types-rs/commit/406c9fd5bbaa11f79d47e1cbe95f641a987922b2))
-    - Release unleash-types v0.4.0 ([`c5dbbdf`](https://github.com/Unleash/unleash-types-rs/commit/c5dbbdfcd2f518c45a9dda20c449bf38b5e2d692))
-    - Add structs for ClientMetrics ([`47a1cfe`](https://github.com/Unleash/unleash-types-rs/commit/47a1cfec6023e4bb18a61142c69c771e5ca78bef))
-    - Add -rs suffix ([`0a251ea`](https://github.com/Unleash/unleash-types-rs/commit/0a251eaa2bcfec307df4b6aef1dcda28ec8a9838))
-    - Updated repo links after transferring ownership ([`48f001e`](https://github.com/Unleash/unleash-types-rs/commit/48f001e044f058cdce0bfa07fe7c839c7f37748b))
-</details>
-
-## v0.3.0 (2022-12-21)
-
-<csr-id-322465f4ebb3a94e3dd37306724f71c499d2d40e/>
-
-### Chore
-
- - <csr-id-322465f4ebb3a94e3dd37306724f71c499d2d40e/> Release unleash-types version 0.3.0
-
-### Commit Statistics
-
-<csr-read-only-do-not-edit/>
-
- - 2 commits contributed to the release.
- - 27 days passed between releases.
- - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
- - 0 issues like '(#ID)' were seen in commit messages
-
-### Commit Details
-
-<csr-read-only-do-not-edit/>
-
-<details><summary>view details</summary>
-
- * **Uncategorized**
-    - Release unleash-types version 0.3.0 ([`322465f`](https://github.com/Unleash/unleash-types-rs/commit/322465f4ebb3a94e3dd37306724f71c499d2d40e))
-    - Added type for frontend results ([`8b43e86`](https://github.com/Unleash/unleash-types-rs/commit/8b43e8631d1afdb24ce7181feb39f5754ed8fbd3))
-</details>
-
-## v0.2.1 (2022-11-24)
-
-<csr-id-3338859afa3650bf35f63a5f5ec4a1b48908b1b3/>
-
-### Chore
-
- - <csr-id-3338859afa3650bf35f63a5f5ec4a1b48908b1b3/> Release unleash-types version 0.2.1
-
-### Commit Statistics
-
-<csr-read-only-do-not-edit/>
-
- - 2 commits contributed to the release.
- - 1 day passed between releases.
- - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
- - 0 issues like '(#ID)' were seen in commit messages
-
-### Commit Details
-
-<csr-read-only-do-not-edit/>
-
-<details><summary>view details</summary>
-
- * **Uncategorized**
-    - Release unleash-types version 0.2.1 ([`3338859`](https://github.com/Unleash/unleash-types-rs/commit/3338859afa3650bf35f63a5f5ec4a1b48908b1b3))
-    - Patch constraint operators to correctly handle StrEndsWith and unknown cases ([`9ccf3e6`](https://github.com/Unleash/unleash-types-rs/commit/9ccf3e6f1039756506ff6e1e4a6ee7387035cfae))
-</details>
-
-## v0.2.0 (2022-11-22)
-
-<csr-id-b17a4af499f1775185955eefe0d52eaff20fa860/>
-<csr-id-bdc0da41e2025894d76486130961747e0028fb87/>
-
-### Chore
-
- - <csr-id-b17a4af499f1775185955eefe0d52eaff20fa860/> Release unleash-types version 0.2.0
-
-### Other
-
- - <csr-id-bdc0da41e2025894d76486130961747e0028fb87/> move client_features to separate mod
-
-### Commit Statistics
-
-<csr-read-only-do-not-edit/>
-
- - 4 commits contributed to the release.
- - 2 commits were understood as [conventional](https://www.conventionalcommits.org).
- - 0 issues like '(#ID)' were seen in commit messages
-
-### Commit Details
-
-<csr-read-only-do-not-edit/>
-
-<details><summary>view details</summary>
-
- * **Uncategorized**
-    - Release unleash-types version 0.2.0 ([`b17a4af`](https://github.com/Unleash/unleash-types-rs/commit/b17a4af499f1775185955eefe0d52eaff20fa860))
-    - Revert "bump version" ([`bfac2fb`](https://github.com/Unleash/unleash-types-rs/commit/bfac2fb8675ad660c042e0174df745140d8f52bf))
-    - Bump version ([`6e1172a`](https://github.com/Unleash/unleash-types-rs/commit/6e1172a4ee82470d3fdfe55d22cf8dafd8ebe8db))
-    - Move client_features to separate mod ([`bdc0da4`](https://github.com/Unleash/unleash-types-rs/commit/bdc0da41e2025894d76486130961747e0028fb87))
-</details>
-
-## v0.1.0 (2022-11-22)
-
-### Commit Statistics
-
-<csr-read-only-do-not-edit/>
-
- - 3 commits contributed to the release.
- - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
- - 0 issues like '(#ID)' were seen in commit messages
-
-### Commit Details
-
-<csr-read-only-do-not-edit/>
-
-<details><summary>view details</summary>
-
- * **Uncategorized**
-    - Add tests for deserialization ([`f3d1f88`](https://github.com/Unleash/unleash-types-rs/commit/f3d1f8893547b056fde96db46ae0c89947813e40))
-    - Start working with tests ([`130a113`](https://github.com/Unleash/unleash-types-rs/commit/130a1139db8f0dd9cb8f38b631b6e55f3e4cfa58))
-    - Initial work with types from Client API response ([`dacb34d`](https://github.com/Unleash/unleash-types-rs/commit/dacb34d1105d0782a7d839c02a18d877814d720c))
-</details>
-
+<!-- generated by git-cliff -->

--- a/cliff.toml
+++ b/cliff.toml
@@ -24,7 +24,9 @@ body = """
     {% for commit in commits %}
         - {% if commit.scope %}*({{ commit.scope }})* {% endif %}\
             {% if commit.breaking %}[**breaking**] {% endif %}\
-            {{ commit.message | upper_first }}\
+            {{ commit.message | split(pat="\n") | first | upper_first | trim }}\
+            {% if commit.remote.username %} by @{{ commit.remote.username }}{%- endif %}\
+            {% if commit.remote.pr_number %} in #{{ commit.remote.pr_number }}{%- endif %}
     {% endfor %}
 {% endfor %}\n
 """

--- a/cliff.toml
+++ b/cliff.toml
@@ -49,7 +49,7 @@ postprocessors = [
 # parse the commits based on https://www.conventionalcommits.org
 conventional_commits = true
 # filter out the commits that are not conventional
-filter_unconventional = true
+filter_unconventional = false
 # process each line of a commit as an individual commit
 split_commits = false
 # regex for preprocessing the commit messages

--- a/cliff.toml
+++ b/cliff.toml
@@ -53,10 +53,10 @@ split_commits = false
 # regex for preprocessing the commit messages
 commit_preprocessors = [
   # Replace issue numbers
-  #{ pattern = '\((\w+\s)?#([0-9]+)\)', replace = "([#${2}](<REPO>/issues/${2}))"},
+  { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "([#${2}](<REPO>/issues/${2}))"},
   # Check spelling of the commit with https://github.com/crate-ci/typos
   # If the spelling is incorrect, it will be automatically fixed.
-  #{ pattern = '.*', replace_command = 'typos --write-changes -' },
+  { pattern = '.*', replace_command = 'typos --write-changes -' },
 ]
 # regex for parsing and grouping commits
 commit_parsers = [


### PR DESCRIPTION
What it says on the tin. Replace cargo-smart-release changelog with git cliff changelog