### PR TITLE
chore: release v0.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.15.2](https://github.com/Unleash/unleash-types-rs/compare/v0.15.1...v0.15.2) - 2025-01-07
+
+### 🚀 Features
+- client features delta schema (#57) (by @chriswk) - #57
+
+### Contributors
+
+* @chriswk
+
 ## [0.15.1](https://github.com/Unleash/unleash-types-rs/compare/v0.15.0...v0.15.1) - 2025-01-06
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,9 +296,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.134"
+version = "1.0.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d00f4175c42ee48b15416f6193a959ba3a0d67fc699a0db9ad12df9f83991c7d"
+checksum = "2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9"
 dependencies = [
  "itoa",
  "memchr",
@@ -401,7 +401,7 @@ checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "unleash-types"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unleash-types"
-version = "0.15.1"
+version = "0.15.2"
 edition = "2021"
 authors = [
     "Christopher Kolstad <chriswk@getunleash.io>",


### PR DESCRIPTION
## 🤖 New release
* `unleash-types`: 0.15.1 -> 0.15.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.15.2](https://github.com/Unleash/unleash-types-rs/compare/v0.15.1...v0.15.2) - 2025-01-07

### 🚀 Features
- client features delta schema (#57) (by @chriswk) - #57

### Contributors

* @chriswk
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).