### PR TITLE
feat: allow ClientFeatures to apply deltas to itself

### DIFF
--- a/examples/delta_base.json
+++ b/examples/delta_base.json
@@ -1,0 +1,94 @@
+{
+  "revisionId": 1,
+  "updated": [
+    {
+      "name": "test-flag",
+      "type": "release",
+      "enabled": false,
+      "project": "default",
+      "stale": false,
+      "strategies": [
+        {
+          "name": "flexibleRollout",
+          "constraints": [],
+          "parameters": {
+            "groupId": "test-flag",
+            "rollout": "100",
+            "stickiness": "default"
+          },
+          "variants": []
+        }
+      ],
+      "variants": [],
+      "description": null,
+      "impressionData": false
+    },
+    {
+      "name": "segment-flag",
+      "type": "release",
+      "enabled": true,
+      "project": "default",
+      "stale": false,
+      "strategies": [
+        {
+          "name": "flexibleRollout",
+          "constraints": [],
+          "parameters": {
+            "groupId": "test-flag",
+            "rollout": "100",
+            "stickiness": "default"
+          },
+          "variants": [],
+          "segments": [
+            1
+          ]
+        }
+      ],
+      "variants": [],
+      "description": null,
+      "impressionData": false
+    },
+    {
+      "name": "removed-flag",
+      "type": "release",
+      "enabled": true,
+      "project": "default",
+      "stale": false,
+      "strategies": [
+        {
+          "name": "flexibleRollout",
+          "constraints": [],
+          "parameters": {
+            "groupId": "test-flag",
+            "rollout": "100",
+            "stickiness": "default"
+          },
+          "variants": []
+        }
+      ],
+      "variants": [],
+      "description": null,
+      "impressionData": false
+    }
+  ],
+  "removed": [],
+  "segments": [
+    {
+      "id": 1,
+      "name": "VIPUsers",
+      "constraints": [
+        {
+          "values": [
+            "1",
+            "2",
+            "3"
+          ],
+          "inverted": false,
+          "operator": "IN",
+          "contextName": "userId",
+          "caseInsensitive": false
+        }
+      ]
+    }
+  ]
+}

--- a/examples/delta_patch.json
+++ b/examples/delta_patch.json
@@ -1,0 +1,73 @@
+{
+  "revisionId": 2,
+  "updated": [
+    {
+      "name": "test-flag",
+      "type": "release",
+      "enabled": true,
+      "project": "default",
+      "stale": false,
+      "strategies": [
+        {
+          "name": "flexibleRollout",
+          "constraints": [],
+          "parameters": {
+            "groupId": "test-flag",
+            "rollout": "100",
+            "stickiness": "default"
+          },
+          "variants": []
+        }
+      ],
+      "variants": [],
+      "description": null,
+      "impressionData": false
+    },
+    {
+      "name": "segment-flag",
+      "type": "release",
+      "enabled": true,
+      "project": "default",
+      "stale": false,
+      "strategies": [
+        {
+          "name": "flexibleRollout",
+          "constraints": [],
+          "parameters": {
+            "groupId": "test-flag",
+            "rollout": "100",
+            "stickiness": "default"
+          },
+          "variants": [],
+          "segments": [
+            1
+          ]
+        }
+      ],
+      "variants": [],
+      "description": null,
+      "impressionData": false
+    }
+  ],
+  "removed": ["removed-flag"],
+  "segments": [
+    {
+      "id": 1,
+      "name": "VIPUsers",
+      "constraints": [
+        {
+          "values": [
+            "1",
+            "2",
+            "3",
+            "4"
+          ],
+          "inverted": false,
+          "operator": "IN",
+          "contextName": "userId",
+          "caseInsensitive": false
+        }
+      ]
+    }
+  ]
+}

--- a/src/client_features.rs
+++ b/src/client_features.rs
@@ -492,12 +492,25 @@ pub struct ClientFeaturesDelta {
     pub segments: Option<Vec<Segment>>,
 }
 
+impl ClientFeatures {
+    pub fn take_delta(&mut self, delta: &ClientFeaturesDelta) {
+        let mut features = self.features.clone();
+        features.retain(|f| !delta.removed.contains(&f.name));
+        self.features = features.merge(delta.updated.clone());
+        self.features.sort();
+        self.segments = delta.segments.clone();
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use serde_qs::Config;
     use std::{fs::File, io::BufReader, path::PathBuf};
 
-    use crate::{client_features::ClientFeature, Merge, Upsert};
+    use crate::{
+        client_features::{ClientFeature, ClientFeaturesDelta},
+        Merge, Upsert,
+    };
 
     use super::{ClientFeatures, Constraint, Operator, Segment, Strategy};
     use crate::client_features::Context;
@@ -678,6 +691,25 @@ mod tests {
         assert!(prop_map.contains_key("companyId"));
         assert!(prop_map.contains_key("hello"));
         assert!(prop_map.contains_key("email"));
+    }
+
+    #[test_case("./examples/delta_base.json".into(), "./examples/delta_patch.json".into(); "Base and delta")]
+    pub fn can_take_delta_updates(base: PathBuf, delta: PathBuf) {
+        let base_delta: ClientFeaturesDelta =
+            serde_json::from_reader(read_file(base).unwrap()).unwrap();
+        let mut features = ClientFeatures {
+            version: 2,
+            features: vec![],
+            segments: None,
+            query: None,
+            meta: None,
+        };
+        features.take_delta(&base_delta);
+        assert_eq!(features.features.len(), 3);
+        let delta: ClientFeaturesDelta =
+            serde_json::from_reader(read_file(delta).unwrap()).unwrap();
+        features.take_delta(&delta);
+        assert_eq!(features.features.len(), 2);
     }
 
     #[test]

--- a/src/client_features.rs
+++ b/src/client_features.rs
@@ -494,7 +494,7 @@ pub struct ClientFeaturesDelta {
 
 impl ClientFeatures {
     /// Modifies the current ClientFeatures instance by applying the delta.
-    pub fn take_delta(&mut self, delta: &ClientFeaturesDelta) {
+    pub fn modify_in_place(&mut self, delta: &ClientFeaturesDelta) {
         let mut features = self.features.clone();
         features.retain(|f| !delta.removed.contains(&f.name));
         self.features = features.merge(delta.updated.clone());
@@ -503,7 +503,7 @@ impl ClientFeatures {
     }
 
     /// Returns a new ClientFeatures instance with the delta applied.
-    pub fn apply_delta(&self, delta: &ClientFeaturesDelta) -> ClientFeatures {
+    pub fn modify_and_copy(&self, delta: &ClientFeaturesDelta) -> ClientFeatures {
         let mut features = self.features.clone();
         features.retain(|f| !delta.removed.contains(&f.name));
         let mut updated_features = features.merge(delta.updated.clone());
@@ -721,11 +721,11 @@ mod tests {
             query: None,
             meta: None,
         };
-        features.take_delta(&base_delta);
+        features.modify_in_place(&base_delta);
         assert_eq!(features.features.len(), 3);
         let delta: ClientFeaturesDelta =
             serde_json::from_reader(read_file(delta).unwrap()).unwrap();
-        features.take_delta(&delta);
+        features.modify_in_place(&delta);
         assert_eq!(features.features.len(), 2);
     }
 
@@ -740,11 +740,11 @@ mod tests {
             query: None,
             meta: None,
         };
-        let changed = features.apply_delta(&base_delta);
+        let changed = features.modify_and_copy(&base_delta);
         assert_eq!(changed.features.len(), 3);
         let delta: ClientFeaturesDelta =
             serde_json::from_reader(read_file(delta).unwrap()).unwrap();
-        let second_change = changed.apply_delta(&delta);
+        let second_change = changed.modify_and_copy(&delta);
         assert_eq!(second_change.features.len(), 2);
     }
 

--- a/src/client_features.rs
+++ b/src/client_features.rs
@@ -506,11 +506,12 @@ impl ClientFeatures {
     pub fn apply_delta(&self, delta: &ClientFeaturesDelta) -> ClientFeatures {
         let mut features = self.features.clone();
         features.retain(|f| !delta.removed.contains(&f.name));
-        let features = features.merge(delta.updated.clone());
+        let mut updated_features = features.merge(delta.updated.clone());
+        updated_features.sort();
         let segments = delta.segments.clone();
         ClientFeatures {
             version: self.version,
-            features,
+            features: updated_features,
             segments,
             query: self.query.clone(),
             meta: self.meta.clone(),

--- a/src/client_metrics.rs
+++ b/src/client_metrics.rs
@@ -131,6 +131,7 @@ pub struct ConnectVia {
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Builder)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
+#[derive(Default)]
 pub struct ClientApplication {
     pub app_name: String,
     pub connect_via: Option<Vec<ConnectVia>>,
@@ -146,6 +147,7 @@ pub struct ClientApplication {
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Builder)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
+#[derive(Default)]
 pub struct MetricsMetadata {
     pub sdk_version: Option<String>,
     pub yggdrasil_version: Option<String>,
@@ -249,31 +251,9 @@ mod tests {
 
     use super::*;
 
-    impl Default for ClientApplication {
-        fn default() -> Self {
-            Self {
-                app_name: Default::default(),
-                connect_via: Default::default(),
-                environment: Default::default(),
-                instance_id: Default::default(),
-                interval: Default::default(),
-                started: Default::default(),
-                strategies: Default::default(),
-                metadata: Default::default(),
-            }
-        }
-    }
+    
 
-    impl Default for MetricsMetadata {
-        fn default() -> Self {
-            Self {
-                sdk_version: Default::default(),
-                yggdrasil_version: Default::default(),
-                platform_name: Default::default(),
-                platform_version: Default::default(),
-            }
-        }
-    }
+    
 
     #[test]
     pub fn can_increment_counts() {


### PR DESCRIPTION
So, after discussions with Simon. We realized that it's not only Yggdrasil that needs to know how to apply deltas, so this PR adds a `modify_in_place(&mut self, delta: &ClientFeaturesDelta)` which modifies in place and an `modify_and_copy(&self, delta: &ClientFeaturesDelta) -> ClientFeatures` which returns a new instance of ClientFeatures with the delta applied.