### PR TITLE
chore: release v0.15.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.15.3](https://github.com/Unleash/unleash-types-rs/compare/v0.15.2...v0.15.3) - 2025-01-07
+
+### 🚀 Features
+- allow ClientFeatures to apply deltas to itself (#59) (by @chriswk) - #59
+
+### Contributors
+
+* @chriswk
+
 ## [0.15.2](https://github.com/Unleash/unleash-types-rs/compare/v0.15.1...v0.15.2) - 2025-01-07
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,7 +401,7 @@ checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "unleash-types"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unleash-types"
-version = "0.15.2"
+version = "0.15.3"
 edition = "2021"
 authors = [
     "Christopher Kolstad <chriswk@getunleash.io>",


### PR DESCRIPTION
## 🤖 New release
* `unleash-types`: 0.15.2 -> 0.15.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.15.3](https://github.com/Unleash/unleash-types-rs/compare/v0.15.2...v0.15.3) - 2025-01-07

### 🚀 Features
- allow ClientFeatures to apply deltas to itself (#59) (by @chriswk) - #59

### Contributors

* @chriswk
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).