### PR TITLE
fix: apply delta not updating features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 /target
-.idea

--- a/src/client_metrics.rs
+++ b/src/client_metrics.rs
@@ -251,10 +251,6 @@ mod tests {
 
     use super::*;
 
-
-
-
-
     #[test]
     pub fn can_increment_counts() {
         let mut stats = ToggleStats::default();

--- a/src/client_metrics.rs
+++ b/src/client_metrics.rs
@@ -251,9 +251,9 @@ mod tests {
 
     use super::*;
 
-    
 
-    
+
+
 
     #[test]
     pub fn can_increment_counts() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,19 +44,26 @@ where
 
 impl<T> Merge for Vec<T>
 where
-    T: Hash + Eq,
+    T: Hash + Eq + Clone,
 {
-    fn merge(self, other: Self) -> Self {
-        let mut merged = self;
+    fn merge(mut self, other: Self) -> Self {
+        use std::collections::HashMap;
+
+        let mut position_map: HashMap<T, usize> = self
+            .iter()
+            .enumerate()
+            .map(|(index, item)| (item.clone(), index))
+            .collect();
 
         for item in other {
-            if let Some(pos) = merged.iter().position(|existing| existing == &item) {
-                merged[pos] = item;
+            if let Some(&pos) = position_map.get(&item) {
+                self[pos] = item;
             } else {
-                merged.push(item);
+                position_map.insert(item.clone(), self.len());
+                self.push(item);
             }
         }
-        merged
+        self
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,12 +44,19 @@ where
 
 impl<T> Merge for Vec<T>
 where
-    T: Hash + Eq,
+    T: Eq + Clone,
 {
     fn merge(self, other: Self) -> Self {
         let mut merged = self;
-        merged.extend(other);
-        merged.deduplicate()
+
+        for item in other {
+            if let Some(pos) = merged.iter().position(|existing| existing == &item) {
+                merged[pos] = item;
+            } else {
+                merged.push(item);
+            }
+        }
+        merged
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,7 +167,7 @@ mod tests {
     }
 
     #[test]
-    fn merge_tester() {
+    fn merging_structs_with_hash_implementations_deduplicates_correctly() {
         #[derive(Serialize, Debug, Eq)]
         pub struct MergeTester {
             pub name: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ where
 
 impl<T> Merge for Vec<T>
 where
-    T: Eq + Clone,
+    T: Hash + Eq,
 {
     fn merge(self, other: Self) -> Self {
         let mut merged = self;


### PR DESCRIPTION
Test to verify that delta is applied properly.

If you have existing `ClientFeature`

```
{name: "a", enabled : false}
```

And you get delta

```
{name: "a", enabled : true}
```

It is not updating the enabled value, due to how most likely how  `ClientFeature` eq/hash function works and merge function.

**Solution:**

Updated the merge function, to apply the old features to new features, since hashset does not overwrite if key exists.