### PR TITLE
chore: refactor delta applying to be in generic function

### DIFF
--- a/src/client_features.rs
+++ b/src/client_features.rs
@@ -560,10 +560,12 @@ impl ClientFeatures {
         features.sort();
     }
 
+    /// Modifies the current ClientFeatures instance by applying the events.
     pub fn modify_in_place(&mut self, delta: &ClientFeaturesDelta) {
         Self::apply_delta(&mut self.features, &mut self.segments, delta);
     }
 
+    /// Returns a new ClientFeatures instance with the events applied.
     pub fn modify_and_copy(&self, delta: &ClientFeaturesDelta) -> ClientFeatures {
         let mut new_features = self.features.clone();
         let mut new_segments = self.segments.clone();

--- a/src/client_features.rs
+++ b/src/client_features.rs
@@ -524,6 +524,27 @@ pub struct ClientFeaturesDelta {
 }
 
 impl ClientFeatures {
+    /// Modifies the current ClientFeatures instance by applying the events.
+    pub fn modify_in_place(&mut self, delta: &ClientFeaturesDelta) {
+        Self::apply_delta(&mut self.features, &mut self.segments, delta);
+    }
+
+    /// Returns a new ClientFeatures instance with the events applied.
+    pub fn create_from_delta(&self, delta: &ClientFeaturesDelta) -> ClientFeatures {
+        let mut new_features = self.features.clone();
+        let mut new_segments = self.segments.clone();
+
+        Self::apply_delta(&mut new_features, &mut new_segments, delta);
+
+        ClientFeatures {
+            version: self.version,
+            features: new_features,
+            segments: new_segments,
+            query: self.query.clone(),
+            meta: self.meta.clone(),
+        }
+    }
+
     fn apply_delta(features: &mut Vec<ClientFeature>, segments: &mut Option<Vec<Segment>>, delta: &ClientFeaturesDelta) {
         for event in &delta.events {
             match event {
@@ -558,27 +579,6 @@ impl ClientFeatures {
         }
 
         features.sort();
-    }
-
-    /// Modifies the current ClientFeatures instance by applying the events.
-    pub fn modify_in_place(&mut self, delta: &ClientFeaturesDelta) {
-        Self::apply_delta(&mut self.features, &mut self.segments, delta);
-    }
-
-    /// Returns a new ClientFeatures instance with the events applied.
-    pub fn modify_and_copy(&self, delta: &ClientFeaturesDelta) -> ClientFeatures {
-        let mut new_features = self.features.clone();
-        let mut new_segments = self.segments.clone();
-
-        Self::apply_delta(&mut new_features, &mut new_segments, delta);
-
-        ClientFeatures {
-            version: self.version,
-            features: new_features,
-            segments: new_segments,
-            query: self.query.clone(),
-            meta: self.meta.clone(),
-        }
     }
 }
 

--- a/src/client_features.rs
+++ b/src/client_features.rs
@@ -597,7 +597,7 @@ impl From<ClientFeaturesDelta> for ClientFeatures {
 
 impl From<&ClientFeaturesDelta> for ClientFeatures {
     fn from(value: &ClientFeaturesDelta) -> Self {
-        ClientFeatures::create_from_delta(&value)
+        ClientFeatures::create_from_delta(value)
     }
 }
 

--- a/src/client_features.rs
+++ b/src/client_features.rs
@@ -591,13 +591,13 @@ impl Default for ClientFeatures {
 
 impl From<ClientFeaturesDelta> for ClientFeatures {
     fn from(value: ClientFeaturesDelta) -> Self {
-        ClientFeatures::default().modify_and_copy(&value)
+        ClientFeatures::create_from_delta(&value)
     }
 }
 
 impl From<&ClientFeaturesDelta> for ClientFeatures {
     fn from(value: &ClientFeaturesDelta) -> Self {
-        ClientFeatures::default().modify_and_copy(value)
+        ClientFeatures::create_from_delta(&value)
     }
 }
 
@@ -803,11 +803,11 @@ mod tests {
             query: None,
             meta: None,
         };
-        features.modify_in_place(&base_delta);
+        features.apply_delta(&base_delta);
         assert_eq!(features.features.len(), 3);
         let delta: ClientFeaturesDelta =
             from_reader(read_file(delta).unwrap()).unwrap();
-        features.modify_in_place(&delta);
+        features.apply_delta(&delta);
         assert_eq!(features.features.len(), 2);
     }
 
@@ -825,7 +825,7 @@ mod tests {
         assert_eq!(updated_features.features.len(), expected_feature_count);
 
         let delta_update: ClientFeaturesDelta = from_reader(read_file(delta_path).unwrap()).unwrap();
-        let final_features = updated_features.apply_delta(&delta_update);
+        updated_features.apply_delta(&delta_update);
 
         let mut sorted_delta_features: Vec<ClientFeature> = delta_update
             .events
@@ -841,7 +841,7 @@ mod tests {
         sorted_delta_features.sort();
 
         let serialized_delta_updates = to_string(&sorted_delta_features).unwrap();
-        let serialized_final_features = to_string(&final_features.features).unwrap();
+        let serialized_final_features = to_string(&updated_features.features).unwrap();
 
         assert_eq!(serialized_delta_updates, serialized_final_features);
     }


### PR DESCRIPTION
`modify_in_place` `and` `modify_and_copy` were sharing most of the code. Made a generic function to reduce duplication.

Now we have `apply_delta` and `create_from_delta`