### PR TITLE
fix: add missing name to Segment struct

### DIFF
--- a/examples/15-global-constraints.json
+++ b/examples/15-global-constraints.json
@@ -91,6 +91,7 @@
   "segments": [
     {
       "id": 1,
+      "name": "My version segment",
       "constraints": [
         {
           "contextName": "version",
@@ -101,6 +102,7 @@
     },
     {
       "id": 2,
+      "name": "My other version segment",
       "constraints": [
         {
           "contextName": "version",
@@ -111,6 +113,7 @@
     },
     {
       "id": 3,
+      "name": "My other version segment",
       "constraints": [
         {
           "contextName": "version",
@@ -121,6 +124,7 @@
     },
     {
       "id": 4,
+      "name": "My other version segment",
       "constraints": [
         {
           "contextName": "customName",
@@ -131,6 +135,7 @@
     },
     {
       "id": 5,
+      "name": "My other version segment",
       "constraints": [
         {
           "contextName": "slicesLeft",

--- a/src/client_features.rs
+++ b/src/client_features.rs
@@ -302,6 +302,7 @@ impl Ord for Variant {
 #[serde(rename_all = "camelCase")]
 pub struct Segment {
     pub id: i32,
+    pub name: Option<String>,
     pub constraints: Vec<Constraint>,
 }
 
@@ -902,6 +903,7 @@ mod tests {
             features: vec![],
             segments: Some(vec![
                 Segment {
+                    name: Some("My segment".into()),
                     constraints: vec![Constraint {
                         case_insensitive: false,
                         values: None,
@@ -913,6 +915,7 @@ mod tests {
                     id: 1,
                 },
                 Segment {
+                    name: Some("My segment".into()),
                     constraints: vec![Constraint {
                         case_insensitive: false,
                         values: None,
@@ -932,6 +935,7 @@ mod tests {
             features: vec![],
             segments: Some(vec![
                 Segment {
+                    name: Some("My segment".into()),
                     constraints: vec![Constraint {
                         case_insensitive: false,
                         values: None,
@@ -943,6 +947,7 @@ mod tests {
                     id: 1,
                 },
                 Segment {
+                    name: Some("My segment".into()),
                     constraints: vec![Constraint {
                         case_insensitive: false,
                         values: None,


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
The Unleash server returns the segment's name in the client API endpoint. This is also documented here: https://docs.getunleash.io/reference/api/unleash/get-all-client-features

This is missing here in the types. And thereby not returned by Unleash Edge.

### Important files
The name will be added as an optional property to the Segment struct.

## Discussion points
My reason for making this an Option is to make it backwards compatible if you have multiple unleash edges chained to each other.
