### PR TITLE
feat: add project to feature removed event

### DIFF
--- a/examples/delta_patch.json
+++ b/examples/delta_patch.json
@@ -56,7 +56,8 @@
     {
       "type": "feature-removed",
       "eventId": 2,
-      "featureName": "removed-flag"
+      "featureName": "removed-flag",
+      "project": "default"
     },
     {
       "type": "segment-updated",

--- a/src/client_features.rs
+++ b/src/client_features.rs
@@ -492,6 +492,7 @@ pub enum DeltaEvent {
     FeatureRemoved {
         event_id: u32,
         feature_name: String,
+        project: String,
     },
     /// Event for a segment update.
     SegmentUpdated {
@@ -501,10 +502,7 @@ pub enum DeltaEvent {
     },
     /// Event for a segment removal.
     #[serde(rename_all = "camelCase")]
-    SegmentRemoved {
-        event_id: u32,
-        segment_id: i32,
-    },
+    SegmentRemoved { event_id: u32, segment_id: i32 },
     /// Hydration event for features and segments.
     Hydration {
         #[serde(rename = "eventId")]
@@ -525,7 +523,6 @@ impl DeltaEvent {
         }
     }
 }
-
 
 /// Schema for delta updates of feature configurations.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -548,7 +545,6 @@ impl ClientFeatures {
         client_features.apply_delta_events(delta);
         client_features
     }
-
 
     fn apply_delta_events(&mut self, delta: &ClientFeaturesDelta) {
         let segments = &mut self.segments;
@@ -578,7 +574,11 @@ impl ClientFeatures {
                         segments_list.retain(|s| s.id != *segment_id);
                     }
                 }
-                DeltaEvent::Hydration { features: new_features, segments: new_segments, .. } => {
+                DeltaEvent::Hydration {
+                    features: new_features,
+                    segments: new_segments,
+                    ..
+                } => {
                     *features = new_features.clone();
                     *segments = Some(new_segments.clone());
                 }
@@ -588,7 +588,6 @@ impl ClientFeatures {
         features.sort();
     }
 }
-
 
 impl Default for ClientFeatures {
     fn default() -> Self {
@@ -616,13 +615,13 @@ impl From<&ClientFeaturesDelta> for ClientFeatures {
 
 #[cfg(test)]
 mod tests {
-    use serde_qs::Config;
-    use std::{fs::File, io::BufReader, path::PathBuf};
-    use serde_json::{from_reader, to_string};
     use crate::{
         client_features::{ClientFeature, ClientFeaturesDelta},
         Merge, Upsert,
     };
+    use serde_json::{from_reader, to_string};
+    use serde_qs::Config;
+    use std::{fs::File, io::BufReader, path::PathBuf};
 
     use super::{ClientFeatures, Constraint, DeltaEvent, Operator, Segment, Strategy};
     use crate::client_features::Context;
@@ -807,8 +806,7 @@ mod tests {
 
     #[test_case("./examples/delta_base.json".into(), "./examples/delta_patch.json".into(); "Base and delta")]
     pub fn can_take_delta_updates(base: PathBuf, delta: PathBuf) {
-        let base_delta: ClientFeaturesDelta =
-            from_reader(read_file(base).unwrap()).unwrap();
+        let base_delta: ClientFeaturesDelta = from_reader(read_file(base).unwrap()).unwrap();
         let mut features = ClientFeatures {
             version: 2,
             features: vec![],
@@ -818,16 +816,14 @@ mod tests {
         };
         features.apply_delta(&base_delta);
         assert_eq!(features.features.len(), 3);
-        let delta: ClientFeaturesDelta =
-            from_reader(read_file(delta).unwrap()).unwrap();
+        let delta: ClientFeaturesDelta = from_reader(read_file(delta).unwrap()).unwrap();
         features.apply_delta(&delta);
         assert_eq!(features.features.len(), 2);
     }
 
     #[test_case("./examples/delta_base.json".into(), "./examples/delta_patch.json".into(); "Base and delta")]
     pub fn validate_delta_updates(base_path: PathBuf, delta_path: PathBuf) {
-        let base_delta: ClientFeaturesDelta =
-            from_reader(read_file(base_path).unwrap()).unwrap();
+        let base_delta: ClientFeaturesDelta = from_reader(read_file(base_path).unwrap()).unwrap();
 
         let mut updated_features = ClientFeatures::create_from_delta(&base_delta);
         let expected_feature_count = base_delta
@@ -837,7 +833,8 @@ mod tests {
             .count();
         assert_eq!(updated_features.features.len(), expected_feature_count);
 
-        let delta_update: ClientFeaturesDelta = from_reader(read_file(delta_path).unwrap()).unwrap();
+        let delta_update: ClientFeaturesDelta =
+            from_reader(read_file(delta_path).unwrap()).unwrap();
         updated_features.apply_delta(&delta_update);
 
         let mut sorted_delta_features: Vec<ClientFeature> = delta_update

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,10 +57,10 @@ mod tests {
     use crate::{Deduplicate, Merge};
 
     use super::client_features::*;
+    use serde::Serialize;
     use serde_json::{json, to_string};
     use std::fs;
     use std::hash::{Hash, Hasher};
-    use serde::Serialize;
     use test_case::test_case;
 
     #[test_case("01-simple-examples"; "can parse legacy format")]
@@ -183,18 +183,18 @@ mod tests {
                 self.name == other.name
             }
         }
-        let first = MergeTester{
+        let first = MergeTester {
             name: "susan".to_string(),
             enabled: false,
         };
-        let second = MergeTester{
+        let second = MergeTester {
             name: "susan".to_string(),
             enabled: true,
         };
 
         let result = vec![first].merge(vec![second]);
 
-        let expected = vec![MergeTester{
+        let expected = vec![MergeTester {
             name: "susan".to_string(),
             enabled: true,
         }];


### PR DESCRIPTION
We need project on feature removed event to filter events properly from edge.
Also ran cargo fmt on it.