### PR TITLE
feat: add connection_id for ClientApplication and ClientMetrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.idea

--- a/src/client_metrics.rs
+++ b/src/client_metrics.rs
@@ -681,6 +681,7 @@ mod tests {
             "connectVia": null,
             "environment": "test-env",
             "instanceId": "test-instance-id",
+            "connectionId": "test-connection-id",
             "interval": 15000,
             "started": "1970-01-01T00:16:40Z",
             "strategies": [],

--- a/src/client_metrics.rs
+++ b/src/client_metrics.rs
@@ -101,6 +101,7 @@ pub struct ClientMetrics {
     pub bucket: MetricBucket,
     pub environment: Option<String>,
     pub instance_id: Option<String>,
+    pub connection_id: Option<String>,
     #[serde(flatten)]
     pub metadata: MetricsMetadata,
 }
@@ -137,6 +138,7 @@ pub struct ClientApplication {
     pub connect_via: Option<Vec<ConnectVia>>,
     pub environment: Option<String>,
     pub instance_id: Option<String>,
+    pub connection_id: Option<String>,
     pub interval: u32,
     pub started: DateTime<Utc>,
     pub strategies: Vec<String>,
@@ -162,6 +164,7 @@ impl ClientApplication {
             connect_via: Some(vec![]),
             environment: None,
             instance_id: None,
+            connection_id: None,
             interval,
             started: Utc::now(),
             strategies: vec![],
@@ -225,6 +228,7 @@ impl Merge for ClientApplication {
             app_name: self.app_name,
             environment: self.environment.or(other.environment),
             instance_id: self.instance_id.or(other.instance_id),
+            connection_id: self.connection_id.or(other.connection_id),
             interval: self.interval,
             started: self.started,
             strategies: merged_strategies,
@@ -319,6 +323,7 @@ mod tests {
             interval: 15500,
             environment: Some("development".into()),
             instance_id: Some("instance_id".into()),
+            connection_id: Some("connection_id".into()),
             started: Utc::now(),
             strategies: vec!["default".into(), "gradualRollout".into()],
             metadata: MetricsMetadata {
@@ -336,6 +341,7 @@ mod tests {
             Some("unleash-client-java:7.1.0".into())
         );
         assert_eq!(merged.instance_id, Some("instance_id".into()));
+        assert_eq!(merged.connection_id, Some("connection_id".into()));
         assert_eq!(merged.started, demo_data_orig.started);
         assert_eq!(merged.strategies.len(), 2);
     }
@@ -635,6 +641,7 @@ mod tests {
             },
             "environment": "test-env",
             "instanceId": "test-instance-id",
+            "connectionId": "test-connection-id",
             "sdkVersion": "rust-1.3.0",
             "yggdrasilVersion": null,
             "platformName": "rustc",
@@ -648,6 +655,7 @@ mod tests {
             app_name: "test-name".into(),
             environment: Some("test-env".into()),
             instance_id: Some("test-instance-id".into()),
+            connection_id: Some("test-connection-id".into()),
             bucket: MetricBucket {
                 start: DateTime::<Utc>::from_timestamp(1000, 0).unwrap(),
                 stop: DateTime::<Utc>::from_timestamp(1000, 0).unwrap(),
@@ -689,6 +697,7 @@ mod tests {
             app_name: "test-name".into(),
             environment: Some("test-env".into()),
             instance_id: Some("test-instance-id".into()),
+            connection_id: Some("test-connection-id".into()),
             metadata: MetricsMetadata {
                 sdk_version: Some("rust-1.3.0".into()),
                 yggdrasil_version: None,


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Since instance_id can be overwritten and we need stable connection_id I'm introducing the same field we added to all frontend and backend SDKs (except from PHP/Next aka Lambda based model SDKs). I am not sure about the ConnectedVia since it uses instance_id but it's a concept I haven't seen before.

This PR is needed to unblock work on Edge that adds connectionId to registration payload and metrics payload as any other backend SDK. This is not used by Unleash yet until we get full SDK support.

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
