### PR TITLE
feat: looser frontend context deserialization to match unleash/api/frontend

### DIFF
--- a/src/client_features.rs
+++ b/src/client_features.rs
@@ -127,7 +127,13 @@ where
         props
             .into_iter()
             .filter_map(|(k, v)| match v {
-                Some(Value::String(s)) => Some((k, s)),
+                Some(Value::String(s)) => {
+                    if s.is_empty() {
+                        None
+                    } else {
+                        Some((k, s))
+                    }
+                },
                 Some(Value::Number(n)) => Some((k, n.to_string())),
                 Some(Value::Bool(b)) => Some((k, b.to_string())),
                 _ => None,


### PR DESCRIPTION
Changes deserialization of Context to allow json numbers (stringifies), ignore objects and booleans. Changes how nulls are matched but still removes null-properties.
For context native properties (user_id et al) numbers and booleans get converted to strings, objects, nulls, empty strings get None'd