### PR TITLE
feat: impact metrics per env

### DIFF
--- a/src/client_metrics.rs
+++ b/src/client_metrics.rs
@@ -315,6 +315,8 @@ mod tests {
     fn client_metrics_with_impact_metrics_serialization() {
         let impact_metrics = vec![
             ImpactMetric {
+                environment: "development".into(),
+                app_name: "test-app".into(),
                 name: "labeled_counter".into(),
                 help: "with labels".into(),
                 r#type: "counter".into(),

--- a/src/client_metrics.rs
+++ b/src/client_metrics.rs
@@ -315,8 +315,8 @@ mod tests {
     fn client_metrics_with_impact_metrics_serialization() {
         let impact_metrics = vec![
             ImpactMetric {
-                environment: "development".into(),
-                app_name: "test-app".into(),
+                environment: "".into(),
+                app_name: "".into(),
                 name: "labeled_counter".into(),
                 help: "with labels".into(),
                 r#type: "counter".into(),

--- a/src/client_metrics.rs
+++ b/src/client_metrics.rs
@@ -182,6 +182,10 @@ pub struct MetricSample {
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct ImpactMetric {
+    #[serde(skip)]
+    pub app_name: String,
+    #[serde(skip)]
+    pub environment: String,
     pub name: String,
     pub help: String,
     pub r#type: String,

--- a/src/client_metrics.rs
+++ b/src/client_metrics.rs
@@ -182,6 +182,16 @@ pub struct MetricSample {
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct ImpactMetric {
+    pub name: String,
+    pub help: String,
+    pub r#type: String,
+    pub samples: Vec<MetricSample>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Builder)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
+pub struct ImpactMetricEnv {
     #[serde(skip)]
     pub app_name: String,
     #[serde(skip)]
@@ -314,7 +324,7 @@ mod tests {
     #[test]
     fn client_metrics_with_impact_metrics_serialization() {
         let impact_metrics = vec![
-            ImpactMetric {
+            ImpactMetricEnv {
                 environment: "".into(),
                 app_name: "".into(),
                 name: "labeled_counter".into(),


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

ImpactMetrics should be grouped per app and env when batching similar to regular metrics.

In edge I had to do this and this PR makes it obsolete
```
#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
pub struct ExtendedImpactMetric {
    #[serde(flatten)]
    pub impact_metric: ImpactMetric,
    #[serde(skip)]
    pub app_name: String,
    #[serde(skip)]
    pub environment: String,
}
```

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
