### PR TITLE
fix: skip serializing client application projects if they're missing

### DIFF
--- a/src/client_metrics.rs
+++ b/src/client_metrics.rs
@@ -140,6 +140,7 @@ pub struct ClientApplication {
     pub app_name: String,
     pub connect_via: Option<Vec<ConnectVia>>,
     pub environment: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub projects: Option<Vec<String>>,
     pub instance_id: Option<String>,
     pub connection_id: Option<String>,


### PR DESCRIPTION
This field is optional in Unleash but only if the field is completely missing. A null causes a bad validation error. Related to https://github.com/Unleash/unleash-edge/issues/1021, [this comment](https://github.com/Unleash/unleash-edge/issues/1021#issuecomment-3034743684)