### PR TITLE
feat: add SDK flavor metadata to MetricsMetadata

### DIFF
--- a/src/client_metrics.rs
+++ b/src/client_metrics.rs
@@ -604,7 +604,10 @@ impl Merge for ClientApplication {
                     .platform_version
                     .or(other.metadata.platform_version),
                 sdk_flavor: self.metadata.sdk_flavor.or(other.metadata.sdk_flavor),
-                sdk_flavor_version: self.metadata.sdk_flavor_version.or(other.metadata.sdk_flavor_version),
+                sdk_flavor_version: self
+                    .metadata
+                    .sdk_flavor_version
+                    .or(other.metadata.sdk_flavor_version),
             },
         }
     }
@@ -938,7 +941,7 @@ mod tests {
     fn sdk_flavor_is_omitted_when_absent() {
         let json = serde_json::to_string(&MetricsMetadata::default()).unwrap();
 
-        // skip_serializing_if stops 'null' from being sent, 
+        // skip_serializing_if stops 'null' from being sent,
         // so schema, doesn't reject the payload
         assert!(!json.contains(r#""sdkFlavor""#));
         assert!(!json.contains(r#""sdkFlavorVersion""#));

--- a/src/client_metrics.rs
+++ b/src/client_metrics.rs
@@ -170,7 +170,9 @@ pub struct MetricsMetadata {
     pub yggdrasil_version: Option<String>,
     pub platform_name: Option<String>,
     pub platform_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub sdk_flavor: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub sdk_flavor_version: Option<String>,
 }
 

--- a/src/client_metrics.rs
+++ b/src/client_metrics.rs
@@ -510,6 +510,8 @@ impl ClientApplication {
                 yggdrasil_version: None,
                 platform_name: None,
                 platform_version: None,
+                sdk_flavor: None,
+                sdk_flavor_version: None,
             },
         }
     }
@@ -599,6 +601,8 @@ impl Merge for ClientApplication {
                     .metadata
                     .platform_version
                     .or(other.metadata.platform_version),
+                sdk_flavor: self.metadata.sdk_flavor.or(other.metadata.sdk_flavor),
+                sdk_flavor_version: self.metadata.sdk_flavor_version.or(other.metadata.sdk_flavor_version),
             },
         }
     }
@@ -638,6 +642,8 @@ mod tests {
                 yggdrasil_version: None,
                 platform_name: Some("rustc".into()),
                 platform_version: Some("1.7.9".into()),
+                sdk_flavor: Some("rust-1.3.0".into()),
+                sdk_flavor_version: Some("1.7.9".into()),,
             },
         };
 
@@ -855,6 +861,8 @@ mod tests {
                 yggdrasil_version: None,
                 platform_name: Some("rustc".into()),
                 platform_version: Some("1.7.9".into()),
+                sdk_flavor: Some("1.7.9".into()),
+                sdk_flavor_version: Some("1.7.9".into()),
             },
         };
 
@@ -897,6 +905,8 @@ mod tests {
                 yggdrasil_version: None,
                 platform_name: Some("rustc".into()),
                 platform_version: Some("1.7.9".into()),
+                sdk_flavor: Some("1.7.9".into()),
+                sdk_flavor_version: Some("1.7.9".into()),
             },
             connect_via: None,
             interval: 15000,

--- a/src/client_metrics.rs
+++ b/src/client_metrics.rs
@@ -919,6 +919,48 @@ mod tests {
         let json_string = serde_json::to_string(&metrics).unwrap();
         assert_eq!(json_string, expected_registration);
     }
+
+    #[test]
+    fn sdk_flavor_serializes_as_camel_case_when_present() {
+        let metadata = MetricsMetadata {
+            sdk_flavor: Some("unleash-openfeature-rust-provider".into()),
+            sdk_flavor_version: Some("1.3.0".into()),
+            ..Default::default()
+        };
+
+        let json = serde_json::to_string(&metadata).unwrap();
+
+        assert!(json.contains(r#""sdkFlavor":"unleash-openfeature-rust-provider""#));
+        assert!(json.contains(r#""sdkFlavorVersion":"1.3.0""#));
+    }
+
+    #[test]
+    fn sdk_flavor_is_omitted_when_absent() {
+        let json = serde_json::to_string(&MetricsMetadata::default()).unwrap();
+
+        // skip_serializing_if stops 'null' from being sent, 
+        // so schema, doesn't reject the payload
+        assert!(!json.contains(r#""sdkFlavor""#));
+        assert!(!json.contains(r#""sdkFlavorVersion""#));
+    }
+
+    #[test]
+    fn sdk_flavor_round_trips_through_json() {
+        let metadata = MetricsMetadata {
+            sdk_flavor: Some("unleash-openfeature-rust-provider".into()),
+            sdk_flavor_version: Some("1.3.0".into()),
+            ..Default::default()
+        };
+
+        let deserialized: MetricsMetadata =
+            serde_json::from_str(&serde_json::to_string(&metadata).unwrap()).unwrap();
+
+        assert_eq!(
+            deserialized.sdk_flavor.as_deref(),
+            Some("unleash-openfeature-rust-provider"),
+        );
+        assert_eq!(deserialized.sdk_flavor_version.as_deref(), Some("1.3.0"));
+    }
 }
 
 #[cfg(test)]

--- a/src/client_metrics.rs
+++ b/src/client_metrics.rs
@@ -644,8 +644,8 @@ mod tests {
                 yggdrasil_version: None,
                 platform_name: Some("rustc".into()),
                 platform_version: Some("1.7.9".into()),
-                sdk_flavor: Some("rust-1.3.0".into()),
-                sdk_flavor_version: Some("1.7.9".into()),,
+                sdk_flavor: Some("unleash-openfeature-rust-provider".into()),
+                sdk_flavor_version: Some("1.3.0".into()),
             },
         };
 
@@ -863,8 +863,8 @@ mod tests {
                 yggdrasil_version: None,
                 platform_name: Some("rustc".into()),
                 platform_version: Some("1.7.9".into()),
-                sdk_flavor: Some("1.7.9".into()),
-                sdk_flavor_version: Some("1.7.9".into()),
+                sdk_flavor: None,
+                sdk_flavor_version: None,
             },
         };
 
@@ -907,8 +907,8 @@ mod tests {
                 yggdrasil_version: None,
                 platform_name: Some("rustc".into()),
                 platform_version: Some("1.7.9".into()),
-                sdk_flavor: Some("1.7.9".into()),
-                sdk_flavor_version: Some("1.7.9".into()),
+                sdk_flavor: None,
+                sdk_flavor_version: None,
             },
             connect_via: None,
             interval: 15000,

--- a/src/client_metrics.rs
+++ b/src/client_metrics.rs
@@ -170,6 +170,8 @@ pub struct MetricsMetadata {
     pub yggdrasil_version: Option<String>,
     pub platform_name: Option<String>,
     pub platform_version: Option<String>,
+    pub sdk_flavor: Option<String>,
+    pub sdk_flavor_version: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]


### PR DESCRIPTION
### About the changes
-Adds `sdk_flavor` / `sdk_flavor_version` to `MetricsMetadata` so Edge  can report which integration is running on top of the SDK - e.g. an OpenFeature provider.

-Adds serialization as `sdkFlavor` / `sdkFlavorVersion` (like Unleash schema), and flattened into ClientApplication. Also, `skip_serializing_if = Option::is_none` so they're omitted when empty rather than `null` (aligned with backend).

#### 🧪 New test: 
to verify camelCase wire name when set, omitted when absent, and correct json format

Note: no flavor means the fields just don't appear